### PR TITLE
Add clear_cache function to evict Typst compilation cache

### DIFF
--- a/ext/typst/src/lib.rs
+++ b/ext/typst/src/lib.rs
@@ -320,6 +320,10 @@ fn query(
     }
 }
 
+fn clear_cache(_ruby: &Ruby, max_age: usize) {
+    comemo::evict(max_age);
+}
+
 #[magnus::init]
 fn init(ruby: &Ruby) -> Result<(), Error> {
     env_logger::init();
@@ -330,5 +334,6 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     module.define_singleton_method("_to_png", function!(to_png, 6))?;
     module.define_singleton_method("_to_html", function!(to_html, 6))?;
     module.define_singleton_method("_query", function!(query, 10))?;
+    module.define_singleton_method("_clear_cache", function!(clear_cache, 1))?;
     Ok(())
 }

--- a/lib/typst.rb
+++ b/lib/typst.rb
@@ -12,6 +12,10 @@ module Typst
   def self.formats
     @@formats
   end
+
+  def self.clear_cache(max_age: 0)
+    Typst::_clear_cache(max_age)
+  end
 end
 
 require "cgi"

--- a/test/typst_test.rb
+++ b/test/typst_test.rb
@@ -159,4 +159,16 @@ class TypstTest < Test::Unit::TestCase
       processor2.string == "John is 35 years old.\nXoliswa is 45 years old.\n"
     }
   end
+
+  # Compilation succeeds after clearing the cache
+  def test_clear_cache
+    assert {
+      Typst.clear_cache(max_age: 0)
+      Typst::Pdf.new("test.typ")
+      Typst("test.typ").compile(:pdf)
+      Typst.clear_cache(max_age: 0)
+      Typst::Pdf.new("test.typ")
+      Typst("test.typ").compile(:pdf)
+    }
+  end
 end


### PR DESCRIPTION
Adds a module method to allow for eviction of the Typst compilation cache. This is useful for long running processes with many different compilations. Clears the cache similar to [`typst watch`](https://github.com/typst/typst/blob/9f3a9e72326a00306bfc02d9e6b94cb79c9d6e68/crates/typst-cli/src/watch.rs#L87).