### PR TITLE
Return compiler warnings from a successful compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,25 @@ In this document, there are #total-words words all up.
 Typst("package_example.typ").compile(:pdf).write("package_example.pdf")
 ```
 
+### Compiler warnings
+
+A compile can succeed *and* warn. The most common case is an unknown font
+family: typst substitutes a different face, the document is produced, and
+nothing tells you it is in the wrong typeface. Every compiled document carries
+the warnings that came with it.
+
+```ruby
+doc = Typst(body: %{#set text(font: "Not Installed")\n= Hello}).compile(:pdf)
+doc.warnings?
+# => true
+doc.warnings
+# => ["warning: unknown font family: \"Not Installed\"\n  ┌─ /tmp/.../main.typ:1:0\n ..."]
+```
+
+Each entry is one formatted diagnostic, so they can be counted, filtered or
+logged individually. A clean compile returns an empty array. Warnings that
+accompany a compile *error* are still included in the raised message, as before.
+
 ### Query a typst document
 ```ruby
 Typst("readme.typ").query("heading").result

--- a/ext/typst/src/compiler.rs
+++ b/ext/typst/src/compiler.rs
@@ -22,7 +22,7 @@ impl SystemWorld {
         pdf_standards: &[typst_pdf::PdfStandard],
         pretty: bool,
         render_bleed: bool,
-    ) -> StrResult<Vec<Vec<u8>>> {
+    ) -> StrResult<(Vec<Vec<u8>>, Vec<String>)> {
         // Reset everything and ensure that the main file is present.
         self.reset();
         self.source(self.main()).map_err(|err| err.to_string())?;
@@ -32,7 +32,7 @@ impl SystemWorld {
                 let Warned { output, warnings } = typst::compile::<HtmlDocument>(self);
                 match output {
                     Ok(document) => {
-                        Ok(vec![export_html(&document, self, pretty)?])
+                        Ok((vec![export_html(&document, self, pretty)?], self.format_warnings(&warnings)))
                     }
                     Err(errors) => Err(format_diagnostics(self, &errors, &warnings).unwrap().into()),
                 }
@@ -43,24 +43,44 @@ impl SystemWorld {
                     // Export the PDF / PNG.
                     Ok(document) => {
                         // Assert format is "pdf" or "png" or "svg"
-                        match format.unwrap_or("pdf").to_ascii_lowercase().as_str() {
-                            "pdf" => Ok(vec![export_pdf(
+                        let buffers = match format.unwrap_or("pdf").to_ascii_lowercase().as_str() {
+                            "pdf" => vec![export_pdf(
                                 &document,
                                 self,
                                 typst_pdf::PdfStandards::new(pdf_standards)
                                     .map_err(|e| eco_format!("PDF standards error: {:?}", e))
                                     .at(Span::detached()).unwrap(),
                                 pretty,
-                            )?]),
-                            "png" => Ok(export_image(&document, ImageExportFormat::Png, ppi, pretty, render_bleed)?),
-                            "svg" => Ok(export_image(&document, ImageExportFormat::Svg, ppi, pretty, render_bleed)?),
-                            fmt => Err(eco_format!("unknown format: {fmt}")),
-                        }
+                            )?],
+                            "png" => export_image(&document, ImageExportFormat::Png, ppi, pretty, render_bleed)?,
+                            "svg" => export_image(&document, ImageExportFormat::Svg, ppi, pretty, render_bleed)?,
+                            fmt => return Err(eco_format!("unknown format: {fmt}")),
+                        };
+                        Ok((buffers, self.format_warnings(&warnings)))
                     }
                     Err(errors) => Err(format_diagnostics(self, &errors, &warnings).unwrap().into()),
                 }
             }
         }
+    }
+
+    /// One formatted string per warning.
+    ///
+    /// A successful compile can still produce warnings — an unknown font
+    /// family being the one that bites people, because Typst substitutes a
+    /// different face and the document still generates. Previously those were
+    /// dropped on the floor: `format_diagnostics` only ever saw them on the
+    /// error path. Returning them one per entry (rather than as a single
+    /// blob) means a caller can count them, filter them, or attach them to a
+    /// log line without parsing.
+    fn format_warnings(&self, warnings: &[SourceDiagnostic]) -> Vec<String> {
+        warnings
+            .iter()
+            .map(|warning| {
+                format_diagnostics(self, &[], std::slice::from_ref(warning))
+                    .unwrap_or_else(|_| warning.message.to_string())
+            })
+            .collect()
     }
 }
 

--- a/ext/typst/src/lib.rs
+++ b/ext/typst/src/lib.rs
@@ -24,7 +24,7 @@ fn to_html(
     render_bleed: bool,
     pretty: bool,
     sys_inputs: HashMap<String, String>,
-) -> Result<Vec<Vec<u8>>, Error> {
+) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
     let input = input.canonicalize()
         .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
 
@@ -62,11 +62,11 @@ fn to_html(
         .build()
         .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
 
-    let bytes = world
+    let compiled = world
         .compile(Some("html"), None, &Vec::new(), pretty, render_bleed)
         .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
 
-    Ok(bytes)
+    Ok(compiled)
 }
 
 fn to_svg(
@@ -79,7 +79,7 @@ fn to_svg(
     render_bleed: bool,
     pretty: bool,
     sys_inputs: HashMap<String, String>,
-) -> Result<Vec<Vec<u8>>, Error> {
+) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
     let input = input.canonicalize()
         .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
 
@@ -104,11 +104,11 @@ fn to_svg(
         .build()
         .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
 
-    let svg_bytes = world
+    let compiled = world
         .compile(Some("svg"), None, &Vec::new(), pretty, render_bleed)
         .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
 
-    Ok(svg_bytes)
+    Ok(compiled)
 }
 
 fn to_png(
@@ -121,7 +121,7 @@ fn to_png(
     render_bleed: bool,
     sys_inputs: HashMap<String, String>,
     ppi: Option<f32>,
-) -> Result<Vec<Vec<u8>>, Error> {
+) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
     let input = input.canonicalize()
         .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
 
@@ -146,11 +146,11 @@ fn to_png(
         .build()
         .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
 
-    let bytes = world
+    let compiled = world
         .compile(Some("png"), ppi, &Vec::new(), false, render_bleed)
         .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
 
-    Ok(bytes)
+    Ok(compiled)
 }
 
 fn to_pdf(
@@ -163,7 +163,7 @@ fn to_pdf(
     pretty: bool,
     sys_inputs: HashMap<String, String>,
     pdf_standards: Vec<String>,
-) -> Result<Vec<Vec<u8>>, Error> {
+) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
     let input = input.canonicalize()
         .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
 
@@ -217,11 +217,11 @@ fn to_pdf(
         }
     }
 
-    let pdf_bytes = world
+    let compiled = world
         .compile(Some("pdf"), None, &pdf_standards_vec, pretty, true)
         .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
 
-    Ok(pdf_bytes)
+    Ok(compiled)
 }
 
 fn query(

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -2,8 +2,18 @@ module Typst
   class Document
     attr_accessor :bytes
 
-    def initialize(bytes)
+    # Diagnostics the compiler emitted while *succeeding*. An unknown font
+    # family is the common one: Typst substitutes another face, the document
+    # generates, and nothing tells you unless you look here.
+    attr_accessor :warnings
+
+    def initialize(bytes, warnings = [])
       @bytes = bytes
+      @warnings = warnings
+    end
+
+    def warnings?
+      !warnings.empty?
     end
 
     def write_some(filename)

--- a/lib/formats/html_experimental.rb
+++ b/lib/formats/html_experimental.rb
@@ -2,7 +2,8 @@ module Typst
   class HtmlExperimental < Base
     def initialize(*options)
       super(*options)
-      @compiled = HtmlExperimentalDocument.new(Typst::_to_html(*self.typst_pretty_args))
+      bytes, warnings = Typst::_to_html(*self.typst_pretty_args)
+      @compiled = HtmlExperimentalDocument.new(bytes, warnings)
     end
   end
   class HtmlExperimentalDocument < Document

--- a/lib/formats/pdf.rb
+++ b/lib/formats/pdf.rb
@@ -2,7 +2,8 @@ module Typst
   class Pdf < Base
     def initialize(*options)
       super(*options)
-      @compiled = PdfDocument.new(Typst::_to_pdf(*self.typst_pdf_args))
+      bytes, warnings = Typst::_to_pdf(*self.typst_pdf_args)
+      @compiled = PdfDocument.new(bytes, warnings)
     end
   end
   class PdfDocument < Document

--- a/lib/formats/png.rb
+++ b/lib/formats/png.rb
@@ -2,7 +2,8 @@ module Typst
   class Png < Base
     def initialize(*options)
       super(*options)
-      @compiled = PngDocument.new(Typst::_to_png(*self.typst_png_args))
+      bytes, warnings = Typst::_to_png(*self.typst_png_args)
+      @compiled = PngDocument.new(bytes, warnings)
     end
   end
   class PngDocument < Document

--- a/lib/formats/svg.rb
+++ b/lib/formats/svg.rb
@@ -2,7 +2,8 @@ module Typst
   class Svg < Base
     def initialize(*options)
       super(*options)
-      @compiled = SvgDocument.new(Typst::_to_svg(*self.typst_pretty_args))
+      bytes, warnings = Typst::_to_svg(*self.typst_pretty_args)
+      @compiled = SvgDocument.new(bytes, warnings)
     end
   end
   class SvgDocument < Document

--- a/test/typst_test.rb
+++ b/test/typst_test.rb
@@ -192,6 +192,64 @@ class TypstTest < Test::Unit::TestCase
     assert_equal("John is 35 years old.\nXoliswa is 45 years old.\n", processor2.string)
   end
 
+  # A compile can succeed *and* warn. The most common case is an unknown font
+  # family: Typst substitutes a different face, the PDF is produced, and
+  # nothing tells the caller their document is in the wrong typeface.
+  def test_warnings_on_successful_compile
+    document = Typst(
+      body: %{#set text(font: "No Such Font Family ZZZ")\n= Heading},
+      ignore_system_fonts: true
+    ).compile(:pdf)
+
+    assert(document.document.start_with?("%PDF"))
+    assert(document.warnings?)
+    assert(document.warnings.any? { |warning| warning.include?("unknown font family") })
+  end
+
+  def test_no_warnings_on_clean_compile
+    document = Typst(body: %{= Heading\n\nSome text.}).compile(:pdf)
+
+    assert(document.document.start_with?("%PDF"))
+    assert_equal([], document.warnings)
+    assert(!document.warnings?)
+  end
+
+  # test.typ names "Fasthand", which is only on the font path when the test
+  # suite supplies it. Compiled without that path it has always warned and
+  # always substituted another face silently — which is the behaviour this
+  # change exists to make visible.
+  def test_warning_when_a_declared_font_is_not_on_the_path
+    document = Typst("test.typ").compile(:pdf)
+
+    assert(document.warnings?)
+    assert(document.warnings.first.include?("unknown font family"))
+
+    with_font = Typst("test.typ", font_paths: ["fonts/Fasthand/Release/ttf"]).compile(:pdf)
+
+    assert_equal([], with_font.warnings)
+  end
+
+  def test_warnings_are_returned_for_every_format
+    formats = { pdf: :pdf, svg: :svg, png: :png, html_experimental: :html_experimental }
+    formats.each_value do |format|
+      document = Typst(
+        body: %{#set text(font: "No Such Font Family ZZZ")\n= Heading},
+        ignore_system_fonts: true
+      ).compile(format)
+
+      assert(document.warnings.is_a?(Array), "#{format} did not return warnings")
+    end
+  end
+
+  # Errors still carry their warnings inline, as before.
+  def test_compile_error_is_unchanged
+    error = assert_raise(ArgumentError) do
+      Typst(body: %{#let x = }).compile(:pdf)
+    end
+
+    assert(error.message.include?("expected expression"))
+  end
+
   def test_query
     assert {
       Typst("test.typ").query("heading").result


### PR DESCRIPTION
## The problem

`SystemWorld::compile` destructures `Warned { output, warnings }` in both arms, but `warnings` only reaches `format_diagnostics` on the error path. When compilation **succeeds**, the warnings go out of scope and the caller never sees them.

The case that bites is an unknown font family. Typst warns, substitutes a different face, and produces a perfectly valid PDF — so anything running headless has no way to learn its documents have been in the wrong typeface since the base image changed.

This repository's own `test/test.typ` is an example. It declares `font: "Fasthand"`, and every test that compiles it without `font_paths` has been silently substituting:

```
warning: unknown font family: fasthand
  ┌─ test.typ:1:22
  │
1 │ #set text(12pt, font: "Fasthand")
  │                       ^^^^^^^^^^
```

## The change

`SystemWorld::compile` now returns `(Vec<Vec<u8>>, Vec<String>)`. Warnings are formatted one per entry rather than as a single blob, so a caller can count them, filter them, or attach them to a log line without parsing.

Every `Document` carries them:

```ruby
doc = Typst(body: %{#set text(font: "Not Installed")\n= Hi}).compile(:pdf)
doc.warnings?  # => true
doc.warnings   # => ["warning: unknown font family: \"Not Installed\"\n  ┌─ ..."]

Typst(body: "= Clean").compile(:pdf).warnings  # => []
```

Works for `:pdf`, `:svg`, `:png` and `:html_experimental`.

## Compatibility

- **Public Ruby API**: additive. `Document#warnings` and `#warnings?` are new; nothing existing changes shape.
- **Errors**: untouched. Warnings are still folded into the raised message on a compile error, exactly as before.
- **`_to_pdf` / `_to_svg` / `_to_png` / `_to_html`**: these now return a two-element array. They are private (leading underscore) and called only from this gem's own format classes, all four of which are updated in this PR.

If you would rather not change the `_to_*` shape at all, I am happy to rework this as parallel `_to_*_warned` functions instead — say the word.

## Testing

Built and run on macOS/arm64, Ruby 3.3.0, Rust 1.92: **26 tests, 39 assertions, 0 failures, 0 errors**.

Four tests added, covering warnings on success, no warnings on a clean compile, all four formats, and that error behaviour is unchanged. One of them documents the `test.typ` substitution above, asserting it warns without the font path and does not warn with it.

One note for anyone reproducing: `test/fonts/Fasthand` is a submodule, so `git submodule update --init` is needed or three pre-existing tests fail on a missing fixture.

## Why I need this

I am building [typstify](https://github.com/TheSoloHacker47/typstify), a Rails layer on top of this gem. It exposes an `on_warning` hook, and I would rather it actually fire than ship an option that quietly never does. In the meantime it re-implements font resolution in Ruby to cover the one case that matters — which is a lot of code to work around three lines of Rust.