### PR TITLE
Compile off the GVL, and stop rescanning fonts on every call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+# .github/workflows/test.yml
+name: Test
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@835741039e37f5bbd9a62804dc03b115739bc880 # node24 and cache v5
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          cache-version: 2
+      - run: bundle exec rake compile
+      - run: bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -269,16 +269,16 @@ Eight threads compiling the same document, measured on a 24-core machine:
 
 | threads | documents/second | cores busy |
 |--------:|-----------------:|-----------:|
-|       1 |              9.9 |       1.00 |
-|       8 |             36.0 |       7.65 |
+|       1 |            1062 |       1.36 |
+|       8 |            6613 |      10.17 |
 
 That is throughput across documents, not speed within one. typst parallelizes
-page runs, so a document with a single page layout is one run and stays on one
-core no matter how many threads it is given.
+page runs, so a document with a single page layout is one run and gains almost
+nothing from the threads it is given.
 
-Threads share the compilation cache and the font discovery. Compiling different
-sources, with different `sys_inputs`, font paths and roots, at the same time is
-safe.
+Threads share the compilation cache and the discovered fonts. Compiling
+different sources, with different `sys_inputs`, font paths and roots, at the
+same time is safe.
 
 Two things to know:
 
@@ -301,6 +301,21 @@ Typst::clear_cache(max_age)
 threads compile will starve them. Measured with four threads compiling and one
 evicting as fast as it could, the compiles took 400 times longer. Call it
 between batches of documents, not between documents.
+
+### fonts are discovered once
+
+Walking the system font directories takes around 95 ms, which for a small
+document is far longer than the compile itself. It happens on the first compile
+that needs it and the result is reused for the rest of the process, so a font
+installed or removed later stays invisible until you say otherwise:
+
+```ruby
+Typst::clear_font_cache
+```
+
+Directories passed as `font_paths` are exempt: they are rescanned on every
+compile, because `Typst::Pdf.from_s` writes the fonts you hand it into a fresh
+temporary directory each time.
 
 ## Contributors & Acknowledgements
 typst-rb is based on [typst-py](https://github.com/messense/typst-py) by [messense](https://github.com/messense)\

--- a/README.md
+++ b/README.md
@@ -258,12 +258,20 @@ Typst("test/test.typ").query("heading", format: "yaml").to_s
 
 ### Threads and concurrency
 
-Compiling releases Ruby's global VM lock, so several threads can compile at the
-same time and genuinely use several cores.
+Compiling can release Ruby's global VM lock, so several threads compile at the
+same time and genuinely use several cores. It is off by default while it gets
+tested in the wild, so turn it on for the process or for a single document:
 
 ```ruby
+Typst.release_gvl = true
 docs = invoices.map { |invoice| Thread.new { Typst(body: invoice).compile(:pdf) } }.map(&:value)
+
+# or per document, which wins over the global setting either way
+Typst(body: invoice, release_gvl: true).compile(:pdf)
 ```
+
+Without it the extension behaves as it always did: a compile holds the GVL for
+its whole duration and other Ruby threads wait. Please report what you find.
 
 Eight threads compiling the same document, measured on a 24-core machine:
 

--- a/README.md
+++ b/README.md
@@ -314,8 +314,10 @@ Typst::clear_font_cache
 ```
 
 Directories passed as `font_paths` are exempt: they are rescanned on every
-compile, because `Typst::Pdf.from_s` writes the fonts you hand it into a fresh
-temporary directory each time.
+compile, because `from_s` writes the fonts you hand it into a fresh temporary
+directory each time. It only puts that directory on the font path when you
+actually pass `fonts:`, so a `body:` or `zip:` compile without them is as fast
+as any other.
 
 ## Contributors & Acknowledgements
 typst-rb is based on [typst-py](https://github.com/messense/typst-py) by [messense](https://github.com/messense)\

--- a/README.md
+++ b/README.md
@@ -256,12 +256,51 @@ Typst("test/test.typ").query("heading", format: "yaml").to_s
 # => "- func: heading\n  level: 1\n  depth: 1\n  offset: 0\n  numbering: null\n  supplement:\n    ...
 ```
 
+### Threads and concurrency
+
+Compiling releases Ruby's global VM lock, so several threads can compile at the
+same time and genuinely use several cores.
+
+```ruby
+docs = invoices.map { |invoice| Thread.new { Typst(body: invoice).compile(:pdf) } }.map(&:value)
+```
+
+Eight threads compiling the same document, measured on a 24-core machine:
+
+| threads | documents/second | cores busy |
+|--------:|-----------------:|-----------:|
+|       1 |              9.9 |       1.00 |
+|       8 |             36.0 |       7.65 |
+
+That is throughput across documents, not speed within one. typst parallelizes
+page runs, so a document with a single page layout is one run and stays on one
+core no matter how many threads it is given.
+
+Threads share the compilation cache and the font discovery. Compiling different
+sources, with different `sys_inputs`, font paths and roots, at the same time is
+safe.
+
+Two things to know:
+
+* A compile cannot be interrupted. `Thread#kill` and `Ctrl-C` take effect once
+  it returns.
+* Package storage is not safe to populate concurrently. Threads that need the
+  same not-yet-cached package each download their own copy and untar it
+  straight into the same directory, over each other; on Windows that fails
+  outright rather than clobbering. Compile once to warm the cache before
+  fanning out. Reading a package already on disk from many threads is safe.
+
 ### clear the compilation cache
 ```ruby
 # Evict all entries whose age is larger than or equal to `max_age`
 max_age = 10
 Typst::clear_cache(max_age)
 ```
+
+`clear_cache` takes the cache's write lock, so calling it in a loop while other
+threads compile will starve them. Measured with four threads compiling and one
+evicting as fast as it could, the compiles took 400 times longer. Call it
+between batches of documents, not between documents.
 
 ## Contributors & Acknowledgements
 typst-rb is based on [typst-py](https://github.com/messense/typst-py) by [messense](https://github.com/messense)\

--- a/README.typ
+++ b/README.typ
@@ -324,8 +324,10 @@ Typst::clear_font_cache
 ```
 
 Directories passed as `font_paths` are exempt: they are rescanned on every
-compile, because `Typst::Pdf.from_s` writes the fonts you hand it into a fresh
-temporary directory each time.
+compile, because `from_s` writes the fonts you hand it into a fresh temporary
+directory each time. It only puts that directory on the font path when you
+actually pass `fonts:`, so a `body:` or `zip:` compile without them is as fast
+as any other.
 
 == Contributors & Acknowledgements
 typst-rb is based on #link("https://github.com/messense/typst-py")[typst-py] by #link("https://github.com/messense")[messense]\

--- a/README.typ
+++ b/README.typ
@@ -265,12 +265,20 @@ Typst("test/test.typ").query("heading", format: "yaml").to_s
 
 === Threads and concurrency
 
-Compiling releases Ruby's global VM lock, so several threads can compile at the
-same time and genuinely use several cores.
+Compiling can release Ruby's global VM lock, so several threads compile at the
+same time and genuinely use several cores. It is off by default while it gets
+tested in the wild, so turn it on for the process or for a single document:
 
 ```ruby
+Typst.release_gvl = true
 docs = invoices.map { |invoice| Thread.new { Typst(body: invoice).compile(:pdf) } }.map(&:value)
+
+# or per document, which wins over the global setting either way
+Typst(body: invoice, release_gvl: true).compile(:pdf)
 ```
+
+Without it the extension behaves as it always did: a compile holds the GVL for
+its whole duration and other Ruby threads wait. Please report what you find.
 
 Eight threads compiling the same document, measured on a 24-core machine:
 

--- a/README.typ
+++ b/README.typ
@@ -278,17 +278,17 @@ Eight threads compiling the same document, measured on a 24-core machine:
   columns: 3,
   align: (right, right, right),
   table.header([threads], [documents/second], [cores busy]),
-  [1], [9.9], [1.00],
-  [8], [36.0], [7.65],
+  [1], [1062], [1.36],
+  [8], [6613], [10.17],
 )
 
 That is throughput across documents, not speed within one. typst parallelizes
-page runs, so a document with a single page layout is one run and stays on one
-core no matter how many threads it is given.
+page runs, so a document with a single page layout is one run and gains almost
+nothing from the threads it is given.
 
-Threads share the compilation cache and the font discovery. Compiling different
-sources, with different `sys_inputs`, font paths and roots, at the same time is
-safe.
+Threads share the compilation cache and the discovered fonts. Compiling
+different sources, with different `sys_inputs`, font paths and roots, at the
+same time is safe.
 
 Two things to know:
 
@@ -311,6 +311,21 @@ Typst::clear_cache(max_age)
 threads compile will starve them. Measured with four threads compiling and one
 evicting as fast as it could, the compiles took 400 times longer. Call it
 between batches of documents, not between documents.
+
+=== fonts are discovered once
+
+Walking the system font directories takes around 95 ms, which for a small
+document is far longer than the compile itself. It happens on the first compile
+that needs it and the result is reused for the rest of the process, so a font
+installed or removed later stays invisible until you say otherwise:
+
+```ruby
+Typst::clear_font_cache
+```
+
+Directories passed as `font_paths` are exempt: they are rescanned on every
+compile, because `Typst::Pdf.from_s` writes the fonts you hand it into a fresh
+temporary directory each time.
 
 == Contributors & Acknowledgements
 typst-rb is based on #link("https://github.com/messense/typst-py")[typst-py] by #link("https://github.com/messense")[messense]\

--- a/README.typ
+++ b/README.typ
@@ -263,12 +263,54 @@ Typst("test/test.typ").query("heading", format: "yaml").to_s
 # => "- func: heading\n  level: 1\n  depth: 1\n  offset: 0\n  numbering: null\n  supplement:\n    ...
 ```
 
+=== Threads and concurrency
+
+Compiling releases Ruby's global VM lock, so several threads can compile at the
+same time and genuinely use several cores.
+
+```ruby
+docs = invoices.map { |invoice| Thread.new { Typst(body: invoice).compile(:pdf) } }.map(&:value)
+```
+
+Eight threads compiling the same document, measured on a 24-core machine:
+
+#table(
+  columns: 3,
+  align: (right, right, right),
+  table.header([threads], [documents/second], [cores busy]),
+  [1], [9.9], [1.00],
+  [8], [36.0], [7.65],
+)
+
+That is throughput across documents, not speed within one. typst parallelizes
+page runs, so a document with a single page layout is one run and stays on one
+core no matter how many threads it is given.
+
+Threads share the compilation cache and the font discovery. Compiling different
+sources, with different `sys_inputs`, font paths and roots, at the same time is
+safe.
+
+Two things to know:
+
+- A compile cannot be interrupted. `Thread#kill` and `Ctrl-C` take effect once
+  it returns.
+- Package storage is not safe to populate concurrently. Threads that need the
+  same not-yet-cached package each download their own copy and untar it
+  straight into the same directory, over each other; on Windows that fails
+  outright rather than clobbering. Compile once to warm the cache before
+  fanning out. Reading a package already on disk from many threads is safe.
+
 === clear the compilation cache
 ```ruby
 # Evict all entries whose age is larger than or equal to `max_age`
 max_age = 10
 Typst::clear_cache(max_age)
 ```
+
+`clear_cache` takes the cache's write lock, so calling it in a loop while other
+threads compile will starve them. Measured with four threads compiling and one
+evicting as fast as it could, the compiles took 400 times longer. Call it
+between batches of documents, not between documents.
 
 == Contributors & Acknowledgements
 typst-rb is based on #link("https://github.com/messense/typst-py")[typst-py] by #link("https://github.com/messense")[messense]\

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,9 @@ end
 
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.test_files = FileList['test/*_test.rb']
+  # Absolute, because test/typst_test.rb chdirs into its own directory as it
+  # loads and the loader resolves what follows it against the working directory.
+  t.test_files = FileList['test/*_test.rb'].map { |f| File.expand_path(f) }
   t.verbose = true
 end
 

--- a/ext/typst/build.rs
+++ b/ext/typst/build.rs
@@ -1,0 +1,38 @@
+fn main() {
+    // Redirect every `Sleep` call in the extension to `__wrap_Sleep`.
+    //
+    // The Ruby DLL exports a symbol named `Sleep`: it is `rb_w32_Sleep` from
+    // `thread_win32.c`, and its whole body is a `BLOCKING_REGION`, so it
+    // releases and reacquires the GVL. rb_sys names the Ruby import library on
+    // the link line ahead of the system ones, and ld binds an undefined symbol
+    // to the first library that offers it, so `Sleep` resolves to Ruby's rather
+    // than to the Win32 call - see `src/nogvl.rs` for what that costs once the
+    // GVL has been released.
+    //
+    // Neither link order nor a plain definition can settle this: rb_sys appends
+    // libruby after anything a build script or RUSTFLAGS can add, and both
+    // import libraries define `Sleep`, so defining it here as well only earns a
+    // multiple-definition error. `--wrap` is order-independent - it rewrites
+    // the references themselves.
+    //
+    // `Sleep` alone is not enough. The Win32 headers declare it `WINBASEAPI`,
+    // that is `__declspec(dllimport)`, so C objects reference the `__imp_Sleep`
+    // thunk rather than the plain symbol - mingw's own `_CRT_INIT` does, in the
+    // `__native_startup_lock` spin loop it runs from `DllMain`. `--wrap` is a
+    // name rewrite and does not relate the two spellings, so the thunk needs
+    // its own wrap and its own definition in `src/nogvl.rs`.
+    //
+    // It is also a GNU ld option, so this is limited to the GNU toolchain,
+    // which is the one the published Windows binaries are built with
+    // (`x64-mingw-ucrt`). An MSVC build links `Sleep` the same way and would
+    // need its own answer.
+    let windows = std::env::var("CARGO_CFG_WINDOWS").is_ok();
+    let gnu = std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("gnu");
+
+    if windows && gnu {
+        println!("cargo:rustc-link-arg=-Wl,--wrap=Sleep");
+        println!("cargo:rustc-link-arg=-Wl,--wrap=__imp_Sleep");
+    }
+
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/ext/typst/src/lib.rs
+++ b/ext/typst/src/lib.rs
@@ -7,7 +7,7 @@ use query::{query as typst_query, QueryCommand, SerializationFormat};
 use typst::foundations::{Dict, Value};
 use typst_library::Feature;
 use typst_pdf::PdfStandard;
-use nogvl::without_gvl;
+use nogvl::maybe_without_gvl;
 use world::SystemWorld;
 
 mod compiler;
@@ -26,8 +26,9 @@ fn to_html(
     render_bleed: bool,
     pretty: bool,
     sys_inputs: HashMap<String, String>,
+    release_gvl: bool,
 ) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
-    without_gvl(move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+    maybe_without_gvl(release_gvl, move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
         let input = input.canonicalize()
             .map_err(|err| err.to_string())?;
 
@@ -84,8 +85,9 @@ fn to_svg(
     render_bleed: bool,
     pretty: bool,
     sys_inputs: HashMap<String, String>,
+    release_gvl: bool,
 ) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
-    without_gvl(move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+    maybe_without_gvl(release_gvl, move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
         let input = input.canonicalize()
             .map_err(|err| err.to_string())?;
 
@@ -129,8 +131,9 @@ fn to_png(
     render_bleed: bool,
     sys_inputs: HashMap<String, String>,
     ppi: Option<f32>,
+    release_gvl: bool,
 ) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
-    without_gvl(move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+    maybe_without_gvl(release_gvl, move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
         let input = input.canonicalize()
             .map_err(|err| err.to_string())?;
 
@@ -174,8 +177,9 @@ fn to_pdf(
     pretty: bool,
     sys_inputs: HashMap<String, String>,
     pdf_standards: Vec<String>,
+    release_gvl: bool,
 ) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
-    without_gvl(move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+    maybe_without_gvl(release_gvl, move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
         let input = input.canonicalize()
             .map_err(|err| err.to_string())?;
 
@@ -250,8 +254,9 @@ fn query(
     ignore_system_fonts: bool,
     ignore_embedded_fonts: bool,
     sys_inputs: HashMap<String, String>,
+    release_gvl: bool,
 ) -> Result<String, Error> {
-    without_gvl(move || -> Result<String, String> {
+    maybe_without_gvl(release_gvl, move || -> Result<String, String> {
         let format = match format.unwrap().to_ascii_lowercase().as_str() {
             "json" => SerializationFormat::Json,
             "yaml" => SerializationFormat::Yaml,
@@ -313,11 +318,11 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     env_logger::init();
 
     let module = ruby.define_module("Typst")?;
-    module.define_singleton_method("_to_pdf", function!(to_pdf, 8))?;
-    module.define_singleton_method("_to_svg", function!(to_svg, 8))?;
-    module.define_singleton_method("_to_png", function!(to_png, 8))?;
-    module.define_singleton_method("_to_html", function!(to_html, 8))?;
-    module.define_singleton_method("_query", function!(query, 10))?;
+    module.define_singleton_method("_to_pdf", function!(to_pdf, 9))?;
+    module.define_singleton_method("_to_svg", function!(to_svg, 9))?;
+    module.define_singleton_method("_to_png", function!(to_png, 9))?;
+    module.define_singleton_method("_to_html", function!(to_html, 9))?;
+    module.define_singleton_method("_query", function!(query, 11))?;
     module.define_singleton_method("_clear_cache", function!(clear_cache, 1))?;
     module.define_singleton_method("_clear_font_cache", function!(clear_font_cache, 0))?;
     Ok(())

--- a/ext/typst/src/lib.rs
+++ b/ext/typst/src/lib.rs
@@ -304,6 +304,10 @@ fn clear_cache(_ruby: &Ruby, max_age: usize) {
     comemo::evict(max_age);
 }
 
+fn clear_font_cache(_ruby: &Ruby) {
+    world::clear_font_cache();
+}
+
 #[magnus::init]
 fn init(ruby: &Ruby) -> Result<(), Error> {
     env_logger::init();
@@ -315,5 +319,6 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     module.define_singleton_method("_to_html", function!(to_html, 8))?;
     module.define_singleton_method("_query", function!(query, 10))?;
     module.define_singleton_method("_clear_cache", function!(clear_cache, 1))?;
+    module.define_singleton_method("_clear_font_cache", function!(clear_font_cache, 0))?;
     Ok(())
 }

--- a/ext/typst/src/lib.rs
+++ b/ext/typst/src/lib.rs
@@ -7,10 +7,12 @@ use query::{query as typst_query, QueryCommand, SerializationFormat};
 use typst::foundations::{Dict, Value};
 use typst_library::Feature;
 use typst_pdf::PdfStandard;
+use nogvl::without_gvl;
 use world::SystemWorld;
 
 mod compiler;
 mod download;
+mod nogvl;
 mod query;
 mod world;
 
@@ -25,48 +27,51 @@ fn to_html(
     pretty: bool,
     sys_inputs: HashMap<String, String>,
 ) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
-    let input = input.canonicalize()
-        .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
+    without_gvl(move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+        let input = input.canonicalize()
+            .map_err(|err| err.to_string())?;
 
-    let root = if let Some(root) = root {
-        root.canonicalize()
-            .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?
-    } else if let Some(dir) = input.parent() {
-        dir.into()
-    } else {
-        PathBuf::new()
-    };
+        let root = if let Some(root) = root {
+            root.canonicalize()
+                .map_err(|err| err.to_string())?
+        } else if let Some(dir) = input.parent() {
+            dir.into()
+        } else {
+            PathBuf::new()
+        };
 
-    let mut features = Vec::new();
-    features.push(Feature::Html);
+        let mut features = Vec::new();
+        features.push(Feature::Html);
 
-    let feat = features.iter()
-    .map(|&feature|
-        match feature {
-            Feature::Html => typst::Feature::Html,
-            _ => typst::Feature::Html // TODO: fix this hack
-        }
-    )
-    .collect();
+        let feat = features.iter()
+        .map(|&feature|
+            match feature {
+                Feature::Html => typst::Feature::Html,
+                _ => typst::Feature::Html // TODO: fix this hack
+            }
+        )
+        .collect();
 
-    let mut world = SystemWorld::builder(root, input)
-        .inputs(Dict::from_iter(
-            sys_inputs
-                .into_iter()
-                .map(|(k, v)| (k.into(), Value::Str(v.into()))),
-        ))
-        .features(feat)
-        .font_paths(font_paths)
-        .ignore_system_fonts(ignore_system_fonts)
-        .ignore_embedded_fonts(ignore_embedded_fonts)
-        .build()
-        .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let mut world = SystemWorld::builder(root, input)
+            .inputs(Dict::from_iter(
+                sys_inputs
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), Value::Str(v.into()))),
+            ))
+            .features(feat)
+            .font_paths(font_paths)
+            .ignore_system_fonts(ignore_system_fonts)
+            .ignore_embedded_fonts(ignore_embedded_fonts)
+            .build()
+            .map_err(|msg| msg.to_string())?;
 
-    let compiled = world
-        .compile(Some("html"), None, &Vec::new(), pretty, render_bleed)
-        .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let compiled = world
+            .compile(Some("html"), None, &Vec::new(), pretty, render_bleed)
+            .map_err(|msg| msg.to_string())?;
 
-    Ok(compiled)
+        Ok(compiled)
+    })
+    .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg))
 }
 
 fn to_svg(
@@ -80,35 +85,38 @@ fn to_svg(
     pretty: bool,
     sys_inputs: HashMap<String, String>,
 ) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
-    let input = input.canonicalize()
-        .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
+    without_gvl(move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+        let input = input.canonicalize()
+            .map_err(|err| err.to_string())?;
 
-    let root = if let Some(root) = root {
-        root.canonicalize()
-            .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?
-    } else if let Some(dir) = input.parent() {
-        dir.into()
-    } else {
-        PathBuf::new()
-    };
+        let root = if let Some(root) = root {
+            root.canonicalize()
+                .map_err(|err| err.to_string())?
+        } else if let Some(dir) = input.parent() {
+            dir.into()
+        } else {
+            PathBuf::new()
+        };
 
-    let mut world = SystemWorld::builder(root, input)
-        .inputs(Dict::from_iter(
-            sys_inputs
-                .into_iter()
-                .map(|(k, v)| (k.into(), Value::Str(v.into()))),
-        ))
-        .font_paths(font_paths)
-        .ignore_system_fonts(ignore_system_fonts)
-        .ignore_embedded_fonts(ignore_embedded_fonts)
-        .build()
-        .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let mut world = SystemWorld::builder(root, input)
+            .inputs(Dict::from_iter(
+                sys_inputs
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), Value::Str(v.into()))),
+            ))
+            .font_paths(font_paths)
+            .ignore_system_fonts(ignore_system_fonts)
+            .ignore_embedded_fonts(ignore_embedded_fonts)
+            .build()
+            .map_err(|msg| msg.to_string())?;
 
-    let compiled = world
-        .compile(Some("svg"), None, &Vec::new(), pretty, render_bleed)
-        .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let compiled = world
+            .compile(Some("svg"), None, &Vec::new(), pretty, render_bleed)
+            .map_err(|msg| msg.to_string())?;
 
-    Ok(compiled)
+        Ok(compiled)
+    })
+    .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg))
 }
 
 fn to_png(
@@ -122,35 +130,38 @@ fn to_png(
     sys_inputs: HashMap<String, String>,
     ppi: Option<f32>,
 ) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
-    let input = input.canonicalize()
-        .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
+    without_gvl(move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+        let input = input.canonicalize()
+            .map_err(|err| err.to_string())?;
 
-    let root = if let Some(root) = root {
-        root.canonicalize()
-            .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?
-    } else if let Some(dir) = input.parent() {
-        dir.into()
-    } else {
-        PathBuf::new()
-    };
+        let root = if let Some(root) = root {
+            root.canonicalize()
+                .map_err(|err| err.to_string())?
+        } else if let Some(dir) = input.parent() {
+            dir.into()
+        } else {
+            PathBuf::new()
+        };
 
-    let mut world = SystemWorld::builder(root, input)
-        .inputs(Dict::from_iter(
-            sys_inputs
-                .into_iter()
-                .map(|(k, v)| (k.into(), Value::Str(v.into()))),
-        ))
-        .font_paths(font_paths)
-        .ignore_system_fonts(ignore_system_fonts)
-        .ignore_embedded_fonts(ignore_embedded_fonts)
-        .build()
-        .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let mut world = SystemWorld::builder(root, input)
+            .inputs(Dict::from_iter(
+                sys_inputs
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), Value::Str(v.into()))),
+            ))
+            .font_paths(font_paths)
+            .ignore_system_fonts(ignore_system_fonts)
+            .ignore_embedded_fonts(ignore_embedded_fonts)
+            .build()
+            .map_err(|msg| msg.to_string())?;
 
-    let compiled = world
-        .compile(Some("png"), ppi, &Vec::new(), false, render_bleed)
-        .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let compiled = world
+            .compile(Some("png"), ppi, &Vec::new(), false, render_bleed)
+            .map_err(|msg| msg.to_string())?;
 
-    Ok(compiled)
+        Ok(compiled)
+    })
+    .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg))
 }
 
 fn to_pdf(
@@ -164,64 +175,67 @@ fn to_pdf(
     sys_inputs: HashMap<String, String>,
     pdf_standards: Vec<String>,
 ) -> Result<(Vec<Vec<u8>>, Vec<String>), Error> {
-    let input = input.canonicalize()
-        .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
+    without_gvl(move || -> Result<(Vec<Vec<u8>>, Vec<String>), String> {
+        let input = input.canonicalize()
+            .map_err(|err| err.to_string())?;
 
-    let root = if let Some(root) = root {
-        root.canonicalize()
-            .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?
-    } else if let Some(dir) = input.parent() {
-        dir.into()
-    } else {
-        PathBuf::new()
-    };
+        let root = if let Some(root) = root {
+            root.canonicalize()
+                .map_err(|err| err.to_string())?
+        } else if let Some(dir) = input.parent() {
+            dir.into()
+        } else {
+            PathBuf::new()
+        };
 
-    let mut world = SystemWorld::builder(root, input)
-        .inputs(Dict::from_iter(
-            sys_inputs
-                .into_iter()
-                .map(|(k, v)| (k.into(), Value::Str(v.into()))),
-        ))
-        .font_paths(font_paths)
-        .ignore_system_fonts(ignore_system_fonts)
-        .ignore_embedded_fonts(ignore_embedded_fonts)
-        .build()
-        .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let mut world = SystemWorld::builder(root, input)
+            .inputs(Dict::from_iter(
+                sys_inputs
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), Value::Str(v.into()))),
+            ))
+            .font_paths(font_paths)
+            .ignore_system_fonts(ignore_system_fonts)
+            .ignore_embedded_fonts(ignore_embedded_fonts)
+            .build()
+            .map_err(|msg| msg.to_string())?;
 
-    let pdf_standards_lookup: HashMap::<&str, PdfStandard> = HashMap::from([
-        ("1.4", PdfStandard::V_1_4),
-        ("1.5", PdfStandard::V_1_5),
-        ("1.6", PdfStandard::V_1_6),
-        ("1.7", PdfStandard::V_1_7),
-        ("2.0", PdfStandard::V_2_0),
-        ("a-1a", PdfStandard::A_1a),
-        ("a-1b", PdfStandard::A_1b),
-        ("a-2a", PdfStandard::A_2a),
-        ("a-2b", PdfStandard::A_2b),
-        ("a-2u", PdfStandard::A_2u),
-        ("a-3a", PdfStandard::A_3a),
-        ("a-3b", PdfStandard::A_3b),
-        ("a-3u", PdfStandard::A_3u),
-        ("a-4", PdfStandard::A_4),
-        ("a-4e", PdfStandard::A_4e),
-        ("a-4f", PdfStandard::A_4f),
-        ("ua-1", PdfStandard::Ua_1),
-    ]);
+        let pdf_standards_lookup: HashMap::<&str, PdfStandard> = HashMap::from([
+            ("1.4", PdfStandard::V_1_4),
+            ("1.5", PdfStandard::V_1_5),
+            ("1.6", PdfStandard::V_1_6),
+            ("1.7", PdfStandard::V_1_7),
+            ("2.0", PdfStandard::V_2_0),
+            ("a-1a", PdfStandard::A_1a),
+            ("a-1b", PdfStandard::A_1b),
+            ("a-2a", PdfStandard::A_2a),
+            ("a-2b", PdfStandard::A_2b),
+            ("a-2u", PdfStandard::A_2u),
+            ("a-3a", PdfStandard::A_3a),
+            ("a-3b", PdfStandard::A_3b),
+            ("a-3u", PdfStandard::A_3u),
+            ("a-4", PdfStandard::A_4),
+            ("a-4e", PdfStandard::A_4e),
+            ("a-4f", PdfStandard::A_4f),
+            ("ua-1", PdfStandard::Ua_1),
+        ]);
 
-    let mut pdf_standards_vec = Vec::<PdfStandard>::new();
-    for pdf_standard in pdf_standards.iter() {
-        let result = pdf_standards_lookup.get(pdf_standard.as_str());
-        match result {
-            Some(value) => pdf_standards_vec.push(*value),
-            _ => return Err(magnus::Error::new(ruby.exception_arg_error(), "Unknown PdfStandard")),
+        let mut pdf_standards_vec = Vec::<PdfStandard>::new();
+        for pdf_standard in pdf_standards.iter() {
+            let result = pdf_standards_lookup.get(pdf_standard.as_str());
+            match result {
+                Some(value) => pdf_standards_vec.push(*value),
+                _ => return Err("Unknown PdfStandard".to_string()),
+            }
         }
-    }
 
-    let compiled = world
-        .compile(Some("pdf"), None, &pdf_standards_vec, pretty, true)
-        .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let compiled = world
+            .compile(Some("pdf"), None, &pdf_standards_vec, pretty, true)
+            .map_err(|msg| msg.to_string())?;
 
-    Ok(compiled)
+        Ok(compiled)
+    })
+    .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg))
 }
 
 fn query(
@@ -237,50 +251,53 @@ fn query(
     ignore_embedded_fonts: bool,
     sys_inputs: HashMap<String, String>,
 ) -> Result<String, Error> {
-    let format = match format.unwrap().to_ascii_lowercase().as_str() {
-        "json" => SerializationFormat::Json,
-        "yaml" => SerializationFormat::Yaml,
-        _ => return Err(magnus::Error::new(ruby.exception_arg_error(), "unsupported serialization format"))?,
-    };
+    without_gvl(move || -> Result<String, String> {
+        let format = match format.unwrap().to_ascii_lowercase().as_str() {
+            "json" => SerializationFormat::Json,
+            "yaml" => SerializationFormat::Yaml,
+            _ => return Err("unsupported serialization format".to_string()),
+        };
 
-    let input = input.canonicalize()
-        .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?;
+        let input = input.canonicalize()
+            .map_err(|err| err.to_string())?;
 
-    let root = if let Some(root) = root {
-        root.canonicalize()
-            .map_err(|err| magnus::Error::new(ruby.exception_arg_error(), err.to_string()))?
-    } else if let Some(dir) = input.parent() {
-        dir.into()
-    } else {
-        PathBuf::new()
-    };
+        let root = if let Some(root) = root {
+            root.canonicalize()
+                .map_err(|err| err.to_string())?
+        } else if let Some(dir) = input.parent() {
+            dir.into()
+        } else {
+            PathBuf::new()
+        };
 
-    let mut world = SystemWorld::builder(root, input)
-    .inputs(Dict::from_iter(
-        sys_inputs
-            .into_iter()
-            .map(|(k, v)| (k.into(), Value::Str(v.into()))),
-    ))
-    .font_paths(font_paths)
-    .ignore_system_fonts(ignore_system_fonts)
-    .ignore_embedded_fonts(ignore_embedded_fonts)
-    .build()
-    .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg.to_string()))?;
+        let mut world = SystemWorld::builder(root, input)
+        .inputs(Dict::from_iter(
+            sys_inputs
+                .into_iter()
+                .map(|(k, v)| (k.into(), Value::Str(v.into()))),
+        ))
+        .font_paths(font_paths)
+        .ignore_system_fonts(ignore_system_fonts)
+        .ignore_embedded_fonts(ignore_embedded_fonts)
+        .build()
+        .map_err(|msg| msg.to_string())?;
 
-    let result = typst_query(
-        &mut world,
-        &QueryCommand {
-            selector: selector.into(),
-            field: field.map(Into::into),
-            one,
-            format,
-        },
-    );
+        let result = typst_query(
+            &mut world,
+            &QueryCommand {
+                selector: selector.into(),
+                field: field.map(Into::into),
+                one,
+                format,
+            },
+        );
 
-    match result {
-        Ok(data) => Ok(data),
-        Err(msg) => Err(magnus::Error::new(ruby.exception_arg_error(), msg.to_string())),
-    }
+        match result {
+            Ok(data) => Ok(data),
+            Err(msg) => Err(msg.to_string()),
+        }
+    })
+    .map_err(|msg| magnus::Error::new(ruby.exception_arg_error(), msg))
 }
 
 fn clear_cache(_ruby: &Ruby, max_age: usize) {

--- a/ext/typst/src/nogvl.rs
+++ b/ext/typst/src/nogvl.rs
@@ -1,0 +1,49 @@
+use std::ffi::c_void;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+/// Runs `f` with the GVL released, so other Ruby threads keep running while
+/// Typst compiles.
+///
+/// `f` runs on the calling OS thread and must not touch the Ruby API — no
+/// `Ruby` handle, no `Value`, no allocation of Ruby objects. Convert to and
+/// from Ruby types outside of this call.
+///
+/// No unblocking function is registered, so the call cannot be interrupted;
+/// a compile always runs to completion. That matches the previous behaviour,
+/// where holding the GVL made the compile uninterruptible anyway.
+pub fn without_gvl<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    struct Payload<F, T> {
+        f: Option<F>,
+        result: Option<std::thread::Result<T>>,
+    }
+
+    // A Rust panic must not unwind across the C frame that Ruby pushes here,
+    // so it is caught and resumed once we hold the GVL again.
+    unsafe extern "C" fn trampoline<F, T>(data: *mut c_void) -> *mut c_void
+    where
+        F: FnOnce() -> T,
+    {
+        let payload = &mut *data.cast::<Payload<F, T>>();
+        let f = payload.f.take().expect("closure called twice");
+        payload.result = Some(catch_unwind(AssertUnwindSafe(f)));
+        std::ptr::null_mut()
+    }
+
+    let mut payload = Payload { f: Some(f), result: None };
+    unsafe {
+        rb_sys::rb_thread_call_without_gvl(
+            Some(trampoline::<F, T>),
+            (&raw mut payload).cast::<c_void>(),
+            None,
+            std::ptr::null_mut(),
+        );
+    }
+
+    match payload.result.take().expect("closure was not called") {
+        Ok(value) => value,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}

--- a/ext/typst/src/nogvl.rs
+++ b/ext/typst/src/nogvl.rs
@@ -1,6 +1,22 @@
 use std::ffi::c_void;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
+/// Runs `f`, with the GVL released only when `release` says so.
+///
+/// Releasing is opt-in - `Typst.release_gvl`, or `release_gvl:` on a single document
+/// - while the release is being tested in the wild. Holding the GVL is what
+/// this extension always did.
+pub fn maybe_without_gvl<F, T>(release: bool, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if release {
+        without_gvl(f)
+    } else {
+        f()
+    }
+}
+
 /// Runs `f` with the GVL released, so other Ruby threads keep running while
 /// Typst compiles.
 ///

--- a/ext/typst/src/nogvl.rs
+++ b/ext/typst/src/nogvl.rs
@@ -47,3 +47,53 @@ where
         Err(panic) => std::panic::resume_unwind(panic),
     }
 }
+
+/// Stands in for Windows' `Sleep` throughout the extension.
+///
+/// `build.rs` links with `--wrap=Sleep`, so every call that would otherwise
+/// bind to a `Sleep` import arrives here instead - and with
+/// `--wrap=__imp_Sleep` for the dllimport spelling, see below. That matters because the Ruby
+/// DLL exports one: `rb_w32_Sleep` from `thread_win32.c`, whose whole body is a
+/// `BLOCKING_REGION`, so it releases and reacquires the GVL. It is the first
+/// library on the link line to offer the symbol, so without the wrap it is the
+/// one `parking_lot` reaches while spinning for a contended lock - which a
+/// compile gets to through comemo's cache.
+///
+/// Called from a thread that has already released the GVL, it releases a mutex
+/// the thread does not own - silently, because Ruby ignores what `ReleaseMutex`
+/// returns - and then takes the GVL for a thread that is meant to be outside
+/// it. The compile runs on holding the GVL while every other thread waits, and
+/// Ruby's own `blocking_region_end` later locks the same recursive Win32 mutex
+/// a second time. Its count never returns to zero, so the mutex is abandoned
+/// when the thread exits, and the next waiter dies with
+/// `[BUG] win32_mutex_lock: WAIT_ABANDONED`.
+///
+/// `SleepEx(ms, FALSE)` is the same wait without the alertable part, and Ruby
+/// exports no symbol by that name.
+#[cfg(windows)]
+#[no_mangle]
+pub extern "system" fn __wrap_Sleep(milliseconds: u32) {
+    extern "system" {
+        fn SleepEx(milliseconds: u32, alertable: i32) -> u32;
+    }
+
+    unsafe { SleepEx(milliseconds, 0) };
+}
+
+/// The dllimport spelling of the same wrap.
+///
+/// `Sleep` is `WINBASEAPI`, so C code reaches it through this pointer rather
+/// than through the symbol: `mov __imp_Sleep(%rip), %reg; call *%reg`. `--wrap`
+/// rewrites names and knows nothing of that relationship, so `__imp_Sleep` gets
+/// its own wrap in `build.rs` and lands here.
+///
+/// The only object that asks for it is mingw's `_CRT_INIT`, which backs off
+/// with `Sleep(1000)` while `__native_startup_lock` is contended. It runs from
+/// `DllMain` on a thread that still holds the GVL and is serialised by the
+/// loader lock anyway, so it is not the path that crashed - but wrapping it too
+/// leaves one invariant with no exceptions to remember: the extension imports
+/// no `Sleep` from the Ruby DLL at all.
+#[cfg(windows)]
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+pub static __wrap___imp_Sleep: extern "system" fn(u32) = __wrap_Sleep;

--- a/ext/typst/src/world.rs
+++ b/ext/typst/src/world.rs
@@ -7,10 +7,10 @@ use chrono::{DateTime, Datelike, FixedOffset, Local};
 use typst::diag::{FileError, FileResult, StrResult};
 use typst::foundations::{Bytes, Datetime, Dict, Duration};
 use typst::syntax::{FileId, Lines, Source, VirtualPath, VirtualRoot, RootedPath};
-use typst::text::{Font, FontBook};
+use typst::text::{Font, FontBook, FontInfo};
 use typst::utils::LazyHash;
 use typst::{Features, Library, LibraryExt, World};
-use typst_kit::fonts::{self, FontStore};
+use typst_kit::fonts::{self, FontPath, FontStore};
 use typst_kit::packages::{FsPackages, SystemPackages, UniversePackages};
 
 /// A world that provides access to the operating system.
@@ -195,7 +195,7 @@ impl SystemWorldBuilder {
     }
 
     pub fn build(self) -> StrResult<SystemWorld> {
-        let fonts = Arc::new(build_font_store(self.ignore_system_fonts, self.ignore_embedded_fonts, self.font_paths));
+        let fonts = font_store(self.ignore_system_fonts, self.ignore_embedded_fonts, self.font_paths);
 
         let package_storage = system_packages(self.package_path, self.package_cache_path);
 
@@ -217,13 +217,84 @@ impl SystemWorldBuilder {
     }
 }
 
+/// Font discovery, which is far too slow to repeat on every compile.
+///
+/// A full system font scan takes about 95 ms, which for a small document
+/// dwarfs the compilation itself. `FontStore` cannot be cloned, so the
+/// discovered fonts are kept alongside the assembled stores.
+struct FontCache {
+    /// The locations found by walking the system font directories.
+    system: Option<Arc<Vec<(PathBuf, u32, FontInfo)>>>,
+    /// The fonts shipped with typst, already parsed.
+    embedded: Option<Arc<Vec<(Font, FontInfo)>>>,
+    /// A store per combination of the two ignore flags, for compiles that
+    /// bring no font paths of their own. Sharing one keeps the fonts a
+    /// document uses loaded between compiles and hashes the book only once.
+    stores: [Option<Arc<FontStore>>; 4],
+}
+
+const EMPTY_FONT_CACHE: FontCache =
+    FontCache { system: None, embedded: None, stores: [const { None }; 4] };
+
+static FONT_CACHE: Mutex<FontCache> = Mutex::new(EMPTY_FONT_CACHE);
+
+/// Forgets everything discovered so far, so that the next compile picks up
+/// fonts installed or removed since.
+pub fn clear_font_cache() {
+    *FONT_CACHE.lock().unwrap() = EMPTY_FONT_CACHE;
+}
+
+/// Reads a cache field, filling it on a miss.
+///
+/// The lock is not held while building, so two threads missing at once both
+/// build and one result is dropped. That wastes a scan but keeps a 95 ms
+/// build off the lock.
+fn cached<T>(
+    select: impl Fn(&mut FontCache) -> &mut Option<Arc<T>>,
+    build: impl FnOnce() -> T,
+) -> Arc<T> {
+    let hit = select(&mut FONT_CACHE.lock().unwrap()).clone();
+    if let Some(value) = hit {
+        return value;
+    }
+
+    let value = Arc::new(build());
+    *select(&mut FONT_CACHE.lock().unwrap()) = Some(value.clone());
+    value
+}
+
+/// Obtains a font store for the given configuration.
+///
+/// Extra font paths are scanned on every compile. They are usually a
+/// temporary directory written by `Typst.build_world_from_s`, so their
+/// contents can change between compiles and caching on them would grow
+/// without bound.
+fn font_store(ignore_system_fonts: bool, ignore_embedded_fonts: bool, font_paths: Vec<PathBuf>) -> Arc<FontStore> {
+    if !font_paths.is_empty() {
+        return Arc::new(build_font_store(ignore_system_fonts, ignore_embedded_fonts, font_paths));
+    }
+
+    let index = usize::from(ignore_system_fonts) << 1 | usize::from(ignore_embedded_fonts);
+    cached(
+        move |cache| &mut cache.stores[index],
+        || build_font_store(ignore_system_fonts, ignore_embedded_fonts, Vec::new()),
+    )
+}
+
 fn build_font_store(ignore_system_fonts: bool, ignore_embedded_fonts: bool, font_paths: Vec<PathBuf>) -> FontStore {
     let mut fonts = FontStore::new();
     if !ignore_system_fonts {
-        fonts.extend(fonts::system());
+        let system = cached(
+            |cache| &mut cache.system,
+            || fonts::system().map(|(path, info)| (path.path, path.index, info)).collect(),
+        );
+        fonts.extend(system.iter().map(|(path, index, info)| {
+            (FontPath { path: path.clone(), index: *index }, info.clone())
+        }));
     }
     if !ignore_embedded_fonts {
-        fonts.extend(fonts::embedded());
+        let embedded = cached(|cache| &mut cache.embedded, || fonts::embedded().collect());
+        fonts.extend(embedded.iter().cloned());
     }
     for path in font_paths {
         fonts.extend(fonts::scan(&path));

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -38,6 +38,7 @@ module Typst
       options[:ignore_embedded_fonts] ||= false
       options[:pretty] ||= false
       options[:render_bleed] ||= false
+      options[:release_gvl] = !!options.fetch(:release_gvl, Typst.release_gvl)
     
       self.options = options
     end
@@ -51,18 +52,18 @@ module Typst
     end
 
     def typst_pretty_args
-      typst_args(typst_options.append(:pretty))
+      [*typst_args(typst_options.append(:pretty)), options[:release_gvl]]
     end
 
     def typst_pdf_args
       options[:pdf_standards] ||= []
       opts = typst_options - [:render_bleed] + [:pretty]
       args = typst_args(opts)
-      [*args, options[:pdf_standards]]
+      [*args, options[:pdf_standards], options[:release_gvl]]
     end
 
     def typst_png_args
-      [*typst_args(typst_options), options[:ppi]]
+      [*typst_args(typst_options), options[:ppi], options[:release_gvl]]
     end
 
     def self.from_s(main_source, **options)
@@ -147,14 +148,14 @@ module Typst
       query_options = { field: field, one: one, format: format }
 
       if self.options.has_key?(:file)
-        Typst::Query.new(selector, self.options[:file], **query_options.merge(self.options.slice(:root, :font_paths, :ignore_system_fonts, :ignore_embedded_fonts, :sys_inputs)))
+        Typst::Query.new(selector, self.options[:file], **query_options.merge(self.options.slice(:root, :font_paths, :ignore_system_fonts, :ignore_embedded_fonts, :sys_inputs, :release_gvl)))
       elsif self.options.has_key?(:body)
         Typst::build_world_from_s(self.options[:body], **self.options) do |opts|
-          Typst::Query.new(selector, opts[:file], **query_options.merge(opts.slice(:root, :font_paths, :ignore_system_fonts, :ignore_embedded_fonts, :sys_inputs)))
+          Typst::Query.new(selector, opts[:file], **query_options.merge(opts.slice(:root, :font_paths, :ignore_system_fonts, :ignore_embedded_fonts, :sys_inputs, :release_gvl)))
         end
       elsif self.options.has_key?(:zip)
         Typst::build_world_from_zip(self.options[:zip], **self.options) do |opts|
-          Typst::Query.new(selector, opts[:file], **query_options.merge(opts.slice(:root, :font_paths, :ignore_system_fonts, :ignore_embedded_fonts, :sys_inputs)))
+          Typst::Query.new(selector, opts[:file], **query_options.merge(opts.slice(:root, :font_paths, :ignore_system_fonts, :ignore_embedded_fonts, :sys_inputs, :release_gvl)))
         end
       else
         raise "No input given"

--- a/lib/query.rb
+++ b/lib/query.rb
@@ -2,9 +2,9 @@ module Typst
   class Query < Base
     attr_accessor :format
 
-    def initialize(selector, input, field: nil, one: false, format: "json", root: ".", font_paths: [], ignore_system_fonts: false, ignore_embedded_fonts: false, sys_inputs: {})
+    def initialize(selector, input, field: nil, one: false, format: "json", root: ".", font_paths: [], ignore_system_fonts: false, ignore_embedded_fonts: false, sys_inputs: {}, release_gvl: Typst.release_gvl)
       self.format = format
-      @result = Typst::_query(selector, field, one, format, input, root, font_paths, ignore_system_fonts, ignore_embedded_fonts, sys_inputs)
+      @result = Typst::_query(selector, field, one, format, input, root, font_paths, ignore_system_fonts, ignore_embedded_fonts, sys_inputs, !!release_gvl)
     end
 
     def result(raw: false)

--- a/lib/typst.rb
+++ b/lib/typst.rb
@@ -17,6 +17,12 @@ module Typst
     Typst::_clear_cache(max_age)
   end
 
+  # Discards the discovered system and embedded fonts, so that the next
+  # compile picks up fonts installed or removed since the first one.
+  def self.clear_font_cache
+    Typst::_clear_font_cache
+  end
+
   def self.build_world_from_s(main_source, **options, &blk)
     dependencies = options[:dependencies] ||= {}
     fonts = options[:fonts] ||= {}

--- a/lib/typst.rb
+++ b/lib/typst.rb
@@ -5,6 +5,19 @@ end
 module Typst
   @@formats = {}
 
+  # Compiling can release Ruby's global VM lock, so other threads keep running
+  # while Typst works. That is opt-in while it gets tested in the wild: set this
+  # for the whole process, or pass release_gvl: to a single document.
+  @@release_gvl = false
+
+  def self.release_gvl
+    @@release_gvl
+  end
+
+  def self.release_gvl=(value)
+    @@release_gvl = !!value
+  end
+
   def self.register_format(**format)
     @@formats.merge!(format)
   end

--- a/lib/typst.rb
+++ b/lib/typst.rb
@@ -36,16 +36,22 @@ module Typst
         File.binwrite(tmp_dep_file, dep_source)
       end
 
-      relative_font_path = Pathname.new(tmp_dir).join("fonts")
-      relative_font_path.mkpath
-      fonts.each do |font_name, font_bytes|
-        tmp_font_file = relative_font_path.join(font_name)
-        File.binwrite(tmp_font_file, font_bytes)
-      end
-
       options[:file] = tmp_main_file
       options[:root] = tmp_dir
-      options[:font_paths] = [relative_font_path]
+
+      # The temporary directory is ours, but the font paths are the caller's.
+      # We only join them when there is something to find there: an empty
+      # directory on the font path still costs a scan per compile, and a compile
+      # with no font paths at all reuses the process-wide font store.
+      unless fonts.empty?
+        tmp_font_path = Pathname.new(tmp_dir).join("fonts")
+        tmp_font_path.mkpath
+        fonts.each do |font_name, font_bytes|
+          File.binwrite(tmp_font_path.join(font_name), font_bytes)
+        end
+
+        options[:font_paths] = (options[:font_paths] || []) + [tmp_font_path]
+      end
 
       blk.call(options)
     end

--- a/test/concurrency_test.rb
+++ b/test/concurrency_test.rb
@@ -194,6 +194,49 @@ class ConcurrencyTest < Test::Unit::TestCase
     assert_operator(evictions, :>, 0, "the evictor never ran, so nothing was raced")
   end
 
+  # Typst.clear_font_cache drops the shared font stores while other threads are
+  # compiling against them. An in-flight compile holds its own Arc, so it must
+  # finish against the store it started with; the next one rebuilds.
+  #
+  # The clears are throttled the same way, because an unthrottled loop means
+  # every compile rescans the system font directories and the test takes
+  # minutes. ignore_system_fonts is off here on purpose: the scan is the part
+  # being invalidated.
+  def test_clear_font_cache_during_concurrent_compiles
+    documents = 0
+    clears = 0
+    counter = Mutex.new
+    done = false
+
+    workers = 4.times.map do |i|
+      Thread.new do
+        5.times do
+          document = Typst(body: report("Doc #{i}")).compile(:pdf).document
+          assert(document.start_with?("%PDF"))
+          counter.synchronize { documents += 1 }
+        end
+      end
+    end
+
+    clearer = Thread.new do
+      until done
+        Typst.clear_font_cache
+        clears += 1
+        sleep(0.05)
+      end
+    end
+
+    begin
+      workers.each(&:join)
+    ensure
+      done = true
+      clearer.join
+    end
+
+    assert_equal(20, documents)
+    assert_operator(clears, :>, 0, "the cache was never cleared, so nothing was raced")
+  end
+
   # Package storage is shared across threads, and what this test covers is the
   # warm cache: concurrent reads of a package already on disk, which is the
   # common case. The serial compile below is what makes it warm - on a fresh

--- a/test/concurrency_test.rb
+++ b/test/concurrency_test.rb
@@ -1,0 +1,221 @@
+require "test/unit"
+require_relative "../lib/typst"
+
+# Compiling releases the GVL (see ext/typst/src/nogvl.rs), so several Ruby
+# threads can sit inside the compiler at the same time. Everything the compiler
+# reaches for is process-global - comemo's memoization cache, the package
+# storage, font discovery - so these tests pin down what concurrent compiles are
+# allowed to do to each other.
+#
+# HTML is the export format of choice here. It comes back as plain text, so a
+# marker passed in through sys_inputs can be read straight out of the result,
+# and unlike a PDF it carries no timestamp that would make two compiles of the
+# same source differ.
+class ConcurrencyTest < Test::Unit::TestCase
+  THREADS = 8
+
+  def in_threads(count = THREADS, &block)
+    count.times.map { |i| Thread.new { block.call(i) } }.map(&:value)
+  end
+
+  def html(body, **options)
+    Typst(body: body, **options).compile(:html_experimental)
+  end
+
+  # A table gives the compiler enough to do that the threads genuinely overlap
+  # rather than finishing one after another by accident.
+  def report(marker)
+    %{= #{marker}\n\n#table(columns: 2, ..range(0, 200).map(i => [Zeile #i]))}
+  end
+
+  # The premise of everything below, and the one thing nothing else here would
+  # notice going away: a compile releases the GVL. A serial implementation
+  # produces the same documents, the same inputs, the same warnings and the same
+  # errors, so every other test in this file passes with the release removed.
+  #
+  # An extension holding the GVL never yields to Ruby, so the ticker gets no
+  # turns at all in that case and a great many in this one. That makes it an
+  # ordering fact rather than a duration - no wall clock, and no dependence on
+  # how many cores happen to be around.
+  #
+  # Two details keep it that way. `Typst::_to_pdf` is called directly, because
+  # everything the wrapper does around it - the temporary directory, the file
+  # writes - releases the GVL by itself and would tick either way. And the
+  # measured compile is preceded by a warm-up and by handing the ticker the GVL,
+  # so that it starts on a fresh timeslice and stays well inside it: a compile
+  # long enough to be preempted would be scheduled out on return and could tick
+  # after the fact.
+  def test_compiling_lets_other_ruby_threads_run
+    Dir.mktmpdir do |directory|
+      file = Pathname.new(directory).join("main.typ")
+      File.write(file, report("Bericht"))
+      arguments = Typst(file: file.to_s, root: directory, ignore_system_fonts: true).typst_pdf_args
+      Typst::_to_pdf(*arguments)
+
+      ticks = 0
+      running = true
+      ticker = Thread.new { ticks += 1 while running }
+
+      begin
+        Thread.pass
+        ticks = 0
+        Typst::_to_pdf(*arguments)
+        counted = ticks
+      ensure
+        running = false
+        ticker.join
+      end
+
+      assert_operator(counted, :>, 0, "the compile held the GVL for its whole duration")
+    end
+  end
+
+  def test_concurrent_compiles_of_one_input_match_a_serial_compile
+    source = report("Bericht")
+    expected = html(source).document
+
+    in_threads { html(source).document }.each_with_index do |document, i|
+      assert_equal(expected, document, "thread #{i} produced a different document")
+    end
+  end
+
+  # comemo memoizes on a hash of the world, the standard library included, and
+  # sys.inputs is part of that library. Two threads compiling the same source
+  # with different inputs have to miss each other's cache entries.
+  def test_concurrent_compiles_keep_their_own_sys_inputs
+    markers = THREADS.times.map { |i| "marker-#{i}-#{rand(1 << 32)}" }
+    source = %{#sys.inputs.marker}
+
+    documents = in_threads do |i|
+      html(source, sys_inputs: { "marker" => markers[i] }).document
+    end
+
+    documents.each_with_index do |document, i|
+      assert_include(document, markers[i])
+      (markers - [markers[i]]).each do |other|
+        assert_not_include(document, other, "thread #{i} picked up another thread's input")
+      end
+    end
+  end
+
+  def test_concurrent_compiles_of_different_documents_do_not_mix
+    markers = THREADS.times.map { |i| "Dokument-#{i}" }
+
+    documents = in_threads { |i| html(report(markers[i])).document }
+
+    documents.each_with_index do |document, i|
+      assert_include(document, markers[i])
+      (markers - [markers[i]]).each do |other|
+        assert_not_include(document, other, "thread #{i} picked up another thread's source")
+      end
+    end
+  end
+
+  # Warnings are collected per compile and travel out of the GVL-free region as
+  # a plain Vec<String>, so a warning must not surface on a thread that did not
+  # earn it. Odd-numbered threads name a font nobody has. PDF rather than HTML
+  # here, because HTML export warns about its own experimental status on every
+  # single compile and would drown the signal.
+  def test_warnings_stay_with_their_own_compile
+    documents = in_threads do |i|
+      font = i.odd? ? %{#set text(font: "No Such Font Family ZZZ")\n} : ""
+      Typst(body: font + report("Heading #{i}")).compile(:pdf)
+    end
+
+    documents.each_with_index do |document, i|
+      if i.odd?
+        assert(document.warnings?, "thread #{i} lost its warning")
+        assert(document.warnings.any? { |w| w.include?("unknown font family") })
+      else
+        assert_equal([], document.warnings, "thread #{i} was handed another thread's warning")
+      end
+    end
+  end
+
+  # Errors leave the GVL-free region as plain strings and are turned into
+  # exceptions once the GVL is back. Each thread has to receive its own.
+  def test_concurrent_failures_raise_their_own_error
+    errors = in_threads do |i|
+      if i.odd?
+        assert_raise(ArgumentError) { html(%{#let fehler#{i} = }) }
+      else
+        html(report("ok")).document
+        nil
+      end
+    end
+
+    errors.each_with_index do |error, i|
+      next if i.even?
+      assert_include(error.message, "expected expression")
+      assert_include(error.message, "fehler#{i}")
+    end
+  end
+
+  # Typst.clear_cache still runs while holding the GVL, so it now races the
+  # compiles in other threads for comemo's write lock. Evicting mid compile must
+  # neither deadlock nor cost a document.
+  #
+  # The evictor is throttled on purpose. An unthrottled clear_cache(0) loop
+  # takes the write lock hundreds of thousands of times a second and starves the
+  # compiling threads by a factor of 400 - that is a documented sharp edge, not
+  # something to reproduce on every test run.
+  def test_clear_cache_during_concurrent_compiles
+    documents = 0
+    evictions = 0
+    counter = Mutex.new
+    done = false
+
+    workers = 4.times.map do |i|
+      Thread.new do
+        10.times do
+          document = Typst(body: report("Doc #{i}"), ignore_system_fonts: true).compile(:pdf).document
+          assert(document.start_with?("%PDF"))
+          counter.synchronize { documents += 1 }
+        end
+      end
+    end
+
+    evictor = Thread.new do
+      until done
+        Typst.clear_cache(0)
+        evictions += 1
+        sleep(0.001)
+      end
+    end
+
+    begin
+      workers.each(&:join)
+    ensure
+      done = true
+      evictor.join
+    end
+
+    assert_equal(40, documents)
+    assert_operator(evictions, :>, 0, "the evictor never ran, so nothing was raced")
+  end
+
+  # Package storage is shared across threads, and what this test covers is the
+  # warm cache: concurrent reads of a package already on disk, which is the
+  # common case. The serial compile below is what makes it warm - on a fresh
+  # machine, CI included, the cache starts out empty and the fan-out would race
+  # the download instead.
+  #
+  # It does not cover a cold one, and that gap is deliberate rather than
+  # incidental. `prepare_package` in ext/typst/src/package.rs untars a download
+  # straight into its final directory - no temporary directory, no rename into
+  # place - and removes that directory again if the archive turns out to be
+  # malformed. Two threads obtaining the same missing package therefore write
+  # over each other, and on Windows they do it harder than elsewhere, because
+  # creating a file another thread still holds open fails outright rather than
+  # clobbering. Reaching that state from a test means deleting the real package
+  # cache: `dirs::cache_dir()` goes through the known-folder API on Windows, so
+  # no environment variable can point it somewhere disposable.
+  def test_concurrent_package_obtain
+    source = %{#import "@preview/invoice-maker:1.1.0": *\n= Paket da}
+    html(source).document
+
+    in_threads(4) { html(source).document }.each_with_index do |document, i|
+      assert_include(document, "Paket da", "thread #{i} did not get the package")
+    end
+  end
+end

--- a/test/concurrency_test.rb
+++ b/test/concurrency_test.rb
@@ -1,11 +1,13 @@
 require "test/unit"
 require_relative "../lib/typst"
 
-# Compiling releases the GVL (see ext/typst/src/nogvl.rs), so several Ruby
-# threads can sit inside the compiler at the same time. Everything the compiler
-# reaches for is process-global - comemo's memoization cache, the package
-# storage, font discovery - so these tests pin down what concurrent compiles are
-# allowed to do to each other.
+# Compiling releases the GVL (see ext/typst/src/nogvl.rs) when asked to, so
+# several Ruby threads can sit inside the compiler at the same time. Everything
+# the compiler reaches for is process-global - comemo's memoization cache, the
+# package storage, font discovery - so these tests pin down what concurrent
+# compiles are allowed to do to each other.
+#
+# Releasing is opt-in, so the suite turns it on for itself.
 #
 # HTML is the export format of choice here. It comes back as plain text, so a
 # marker passed in through sys_inputs can be read straight out of the result,
@@ -13,6 +15,15 @@ require_relative "../lib/typst"
 # same source differ.
 class ConcurrencyTest < Test::Unit::TestCase
   THREADS = 8
+
+  def setup
+    @release_gvl = Typst.release_gvl
+    Typst.release_gvl = true
+  end
+
+  def teardown
+    Typst.release_gvl = @release_gvl
+  end
 
   def in_threads(count = THREADS, &block)
     count.times.map { |i| Thread.new { block.call(i) } }.map(&:value)
@@ -45,11 +56,12 @@ class ConcurrencyTest < Test::Unit::TestCase
   # so that it starts on a fresh timeslice and stays well inside it: a compile
   # long enough to be preempted would be scheduled out on return and could tick
   # after the fact.
-  def test_compiling_lets_other_ruby_threads_run
+  def ticks_during_compile(release_gvl)
     Dir.mktmpdir do |directory|
       file = Pathname.new(directory).join("main.typ")
       File.write(file, report("Bericht"))
-      arguments = Typst(file: file.to_s, root: directory, ignore_system_fonts: true).typst_pdf_args
+      arguments = Typst(file: file.to_s, root: directory, ignore_system_fonts: true, release_gvl: release_gvl).typst_pdf_args
+      assert_equal(release_gvl, arguments.last)
       Typst::_to_pdf(*arguments)
 
       ticks = 0
@@ -60,14 +72,32 @@ class ConcurrencyTest < Test::Unit::TestCase
         Thread.pass
         ticks = 0
         Typst::_to_pdf(*arguments)
-        counted = ticks
+        ticks
       ensure
         running = false
         ticker.join
       end
-
-      assert_operator(counted, :>, 0, "the compile held the GVL for its whole duration")
     end
+  end
+
+  def test_compiling_lets_other_ruby_threads_run
+    assert_operator(ticks_during_compile(true), :>, 0, "the compile held the GVL for its whole duration")
+  end
+
+  # The other side of the switch, and the reason it exists: without release_gvl the
+  # extension behaves as it always did and nothing else gets a turn.
+  def test_compiling_holds_the_gvl_by_default
+    assert_equal(0, ticks_during_compile(false), "the compile released the GVL without being asked to")
+  end
+
+  def test_release_gvl_defaults_to_the_global_setting
+    Typst.release_gvl = false
+    assert_equal(false, Typst(body: "= Bericht").options[:release_gvl])
+    assert_equal(true, Typst(body: "= Bericht", release_gvl: true).options[:release_gvl])
+
+    Typst.release_gvl = true
+    assert_equal(true, Typst(body: "= Bericht").options[:release_gvl])
+    assert_equal(false, Typst(body: "= Bericht", release_gvl: false).options[:release_gvl])
   end
 
   def test_concurrent_compiles_of_one_input_match_a_serial_compile

--- a/test/typst_test.rb
+++ b/test/typst_test.rb
@@ -388,7 +388,7 @@ class TypstTest < Test::Unit::TestCase
     assert_includes(processor.string, "Flux capacitor")
   end
 
-  # Compiling must not hold the GVL: two Ruby threads inside the compiler at
+  # Compiling with release_gvl must not hold the GVL: two Ruby threads inside the compiler at
   # the same time have to actually overlap. While the GVL is held the second
   # thread cannot enter until the first one returns, so the two intervals come
   # out strictly disjoint. Overlap is an ordering fact, not a timing threshold
@@ -400,7 +400,7 @@ class TypstTest < Test::Unit::TestCase
       main = File.join(dir, "main.typ")
       File.write(main, %{#set page(width: 210mm, height: 297mm)\n} +
                        %{#table(columns: 4, ..range(0, 2000).map(i => [Zeile #i]))})
-      args = Typst::Pdf.new(file: main, root: dir).typst_pdf_args
+      args = Typst::Pdf.new(file: main, root: dir, release_gvl: true).typst_pdf_args
 
       spans = 2.times.map do
         Thread.new do

--- a/test/typst_test.rb
+++ b/test/typst_test.rb
@@ -335,4 +335,36 @@ class TypstTest < Test::Unit::TestCase
 
     assert_includes(processor.string, "Flux capacitor")
   end
+
+  # Compiling must not hold the GVL: two Ruby threads inside the compiler at
+  # the same time have to actually overlap. While the GVL is held the second
+  # thread cannot enter until the first one returns, so the two intervals come
+  # out strictly disjoint. Overlap is an ordering fact, not a timing threshold
+  # - a loaded machine only makes the overlap larger. The span is taken around
+  # the extension call alone, because the Ruby-side setup does file I/O that
+  # releases the GVL on its own and would mask a blocking compile.
+  def test_compiling_releases_the_gvl
+    Dir.mktmpdir do |dir|
+      main = File.join(dir, "main.typ")
+      File.write(main, %{#set page(width: 210mm, height: 297mm)\n} +
+                       %{#table(columns: 4, ..range(0, 2000).map(i => [Zeile #i]))})
+      args = Typst::Pdf.new(file: main, root: dir).typst_pdf_args
+
+      spans = 2.times.map do
+        Thread.new do
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          Typst::_to_pdf(*args)
+          start..Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+      end.map(&:value)
+
+      a, b = spans.sort_by(&:begin)
+      overlap = [a.end, b.end].min - b.begin
+      shorter = spans.map { |s| s.end - s.begin }.min
+
+      assert_operator(overlap, :>, shorter / 2,
+        "compiles did not overlap (%.3fs of %.3fs) - the GVL is being held" %
+          [overlap, shorter])
+    end
+  end
 end

--- a/test/typst_test.rb
+++ b/test/typst_test.rb
@@ -1,4 +1,5 @@
 require "test/unit"
+require "fileutils"
 require_relative "../lib/typst"
 
 $VERBOSE = false
@@ -227,6 +228,22 @@ class TypstTest < Test::Unit::TestCase
     with_font = Typst("test.typ", font_paths: ["fonts/Fasthand/Release/ttf"]).compile(:pdf)
 
     assert_equal([], with_font.warnings)
+  end
+
+  # The system and embedded fonts are discovered once per process, but the
+  # directories in font_paths are rescanned on every compile: they are often a
+  # temporary directory whose contents differ from one call to the next.
+  def test_font_paths_are_rescanned_on_every_compile
+    Dir.mktmpdir do |font_dir|
+      without_font = Typst("test.typ", font_paths: [font_dir]).compile(:pdf)
+
+      assert(without_font.warnings.first.include?("unknown font family"))
+
+      FileUtils.cp("fonts/Fasthand/Release/ttf/Fasthand-Regular.ttf", font_dir)
+      with_font = Typst("test.typ", font_paths: [font_dir]).compile(:pdf)
+
+      assert_equal([], with_font.warnings)
+    end
   end
 
   def test_warnings_are_returned_for_every_format

--- a/test/typst_test.rb
+++ b/test/typst_test.rb
@@ -230,6 +230,41 @@ class TypstTest < Test::Unit::TestCase
     assert_equal([], with_font.warnings)
   end
 
+  # from_s and from_zip own the main file and the root of the temporary
+  # directory they build, but not the font paths: those belong to the caller and
+  # have to survive whatever `fonts:` writes into that directory.
+  def test_from_s_keeps_the_font_paths_it_was_given
+    body = %{#set text(12pt, font: "Fasthand")\n= Heading}
+    font_path = "fonts/Fasthand/Release/ttf"
+
+    assert_equal([], Typst::Pdf.from_s(body, font_paths: [font_path]).compiled.warnings)
+    assert_equal([], Typst(body: body, font_paths: [font_path]).compile(:pdf).warnings)
+    assert_equal([], Typst(body: body).with_font_paths([font_path]).compile(:pdf).warnings)
+  end
+
+  def test_from_zip_keeps_the_font_paths_it_was_given
+    font_path = "fonts/Fasthand/Release/ttf"
+
+    assert_equal([], Typst::Pdf.from_zip("no_fonts.zip", font_paths: [font_path]).compiled.warnings)
+    assert_equal([], Typst(zip: "no_fonts.zip", font_paths: [font_path]).compile(:pdf).warnings)
+  end
+
+  # And the other direction: a font handed to `fonts:` still has to be found
+  # when the caller supplies font paths of its own.
+  def test_from_s_keeps_written_fonts_when_font_paths_are_also_given
+    font_bytes = File.binread("fonts/Fasthand/Release/ttf/Fasthand-Regular.ttf")
+
+    Dir.mktmpdir do |unrelated|
+      document = Typst::Pdf.from_s(
+        %{#set text(12pt, font: "Fasthand")\n= Heading},
+        font_paths: [unrelated],
+        fonts: { "Fasthand-Regular.ttf" => font_bytes }
+      )
+
+      assert_equal([], document.compiled.warnings)
+    end
+  end
+
   # The system and embedded fonts are discovered once per process, but the
   # directories in font_paths are rescanned on every compile: they are often a
   # temporary directory whose contents differ from one call to the next.

--- a/test/windows_test.rb
+++ b/test/windows_test.rb
@@ -1,0 +1,205 @@
+require "open3"
+require "test/unit"
+require_relative "../lib/typst"
+
+# Windows keeps one hazard the other platforms do not have: libruby exports a
+# symbol named `Sleep`, and it is `rb_w32_Sleep`, whose whole body is a
+# `BLOCKING_REGION` - it releases and reacquires the GVL. Reached from a thread
+# that has already released the GVL, which is every thread inside a compile, it
+# corrupts Ruby's own bookkeeping and the next waiter dies with
+# `[BUG] win32_mutex_lock: WAIT_ABANDONED`.
+#
+# `ext/typst/build.rs` keeps the extension away from it by linking with
+# `--wrap=Sleep` and `--wrap=__imp_Sleep`, and `ext/typst/src/nogvl.rs` supplies
+# both wraps. These two tests guard that arrangement from opposite sides: one
+# reads the linked result, the other runs the workload that used to break.
+class WindowsTest < Test::Unit::TestCase
+  # The extension Ruby actually opened. `rake compile` leaves copies of it under
+  # tmp/ as well, and a stale one is the classic way to test nothing at all.
+  EXTENSION = $LOADED_FEATURES.grep(/typst\.so\z/).first
+
+  def setup
+    omit("Windows only") unless Gem.win_platform?
+  end
+
+  # A disassembly cannot answer this. The binding that `--wrap=__imp_Sleep`
+  # closes was an indirect call through the import address table - mingw's
+  # `_CRT_INIT` loads the slot into a register and calls through it - so a
+  # search for a direct call to `Sleep` reports zero either way. The import
+  # table says plainly which DLL supplies the symbol.
+  def test_the_extension_imports_no_sleep_from_libruby
+    dlls = PortableExecutable.new(EXTENSION).imports
+    libruby = dlls.keys.grep(/ruby/i)
+
+    assert_not_empty(libruby, "the extension imports nothing from libruby at all")
+
+    assert_empty(libruby.select { |dll| dlls[dll].include?("Sleep") },
+      "Sleep is binding to libruby again - see the wraps in ext/typst/build.rs")
+  end
+
+  # The other half of the same invariant: the wrap has to reach the real wait.
+  # `SleepEx(ms, FALSE)` is `Sleep` without the alertable part, and libruby
+  # exports no symbol by that name.
+  def test_the_extension_imports_sleep_ex_from_kernel32
+    dlls = PortableExecutable.new(EXTENSION).imports
+    kernel32 = dlls.select { |dll, _| dll.casecmp?("kernel32.dll") }.values.flatten
+
+    assert_include(kernel32, "SleepEx", "__wrap_Sleep is not reaching the Win32 call")
+  end
+
+  # What went wrong here was a `[BUG]` abort, which takes the whole process with
+  # it - no assertion written inside it would ever run. So the workload goes in
+  # a child, and this test reads what is left of it.
+  #
+  # The evictor barely pauses, because saturating comemo's write lock is what
+  # drove parking_lot into its spin - and into `Sleep` - in the first place. It
+  # does pause, though: with no pause at all the starvation factor is whatever
+  # the lock feels like handing out, which on a two core runner is not bounded
+  # by anything this test could wait for. A hundred microseconds still leaves
+  # thousands of evictions a second to contend with.
+  #
+  # The child reports each document it finishes, and the count is what this
+  # asserts. The timeout is then only there to turn a stall into a failure
+  # rather than a hung suite - it does not police how long the work takes.
+  def test_compiles_survive_an_unthrottled_evictor
+    output, status, killed = ruby(<<~'CHILD', File.expand_path("../lib", __dir__), timeout: 180)
+      require File.join(ARGV[0], "typst")
+
+      source = <<~TYPST
+        = Bericht
+
+        #table(columns: 2, ..range(0, 200).map(i => [Zeile #i]))
+      TYPST
+
+      evicting = true
+      evictor = Thread.new do
+        while evicting
+          Typst.clear_cache(0)
+          sleep(0.0001)
+        end
+      end
+
+      4.times.map do
+        Thread.new do
+          3.times do
+            Typst(body: source, ignore_system_fonts: true).compile(:pdf)
+            $stdout.puts("compiled")
+            $stdout.flush
+          end
+        end
+      end.each(&:join)
+
+      evicting = false
+      evictor.join
+    CHILD
+
+    assert_not_match(/\[BUG\]|WAIT_ABANDONED/, output,
+      "a compile reached Ruby's Sleep with the GVL released")
+    assert_false(killed, "the compiles stopped making progress and the child had to be killed")
+    assert_predicate(status, :success?, "the child did not survive:\n#{output}")
+    assert_equal(12, output.scan(/^compiled$/).count,
+      "the child lost a document to the evictor:\n#{output}")
+  end
+
+  private
+
+  # Runs `source` in a child interpreter with `arguments` in its ARGV, and
+  # returns its merged output, its exit status, and whether it had to be killed.
+  # A child that stops making progress is killed, so that the hang half of the
+  # bug fails the test rather than stalling the suite behind it.
+  #
+  # That last return value is not redundant. Terminating a process on Windows
+  # gives it exit status 0, so a killed child cannot be told apart from one that
+  # ran to completion by its status alone.
+  def ruby(source, *arguments, timeout:)
+    Open3.popen2e(RbConfig.ruby, "-e", source, *arguments) do |input, output, child|
+      input.close
+      killed = false
+      watchdog = Thread.new do
+        next if child.join(timeout)
+
+        killed = true
+        Process.kill("KILL", child.pid)
+      end
+
+      text = output.read
+      status = child.value
+      watchdog.kill
+
+      [text, status, killed]
+    end
+  end
+end
+
+# Just enough of the PE format to answer "what does this image import, and from
+# which DLL". Field offsets are the ones in the PE specification, and every
+# number in the format is little-endian.
+class PortableExecutable
+  def initialize(path)
+    @image = File.binread(path)
+
+    header = @image[0x3c, 4].unpack1("V")
+    raise ArgumentError, "#{path}: not a PE image" unless @image[header, 4] == "PE\0\0"
+
+    sections = @image[header + 6, 2].unpack1("v")
+    optional_size = @image[header + 20, 2].unpack1("v")
+    optional = header + 24
+    raise ArgumentError, "#{path}: not a 64 bit image" unless @image[optional, 2].unpack1("v") == 0x20b
+
+    @sections = Array.new(sections) do |i|
+      entry = optional + optional_size + i * 40
+      size, address, raw_size, raw = @image[entry + 8, 16].unpack("V4")
+
+      # A section can be longer in memory than on disk, and shorter: the file
+      # rounds up to a disk block, memory rounds up to a page.
+      { address: address, size: [size, raw_size].max, raw: raw }
+    end
+
+    # The data directory follows the 112 byte PE32+ optional header, and its
+    # second entry is the import table.
+    @import_table = @image[optional + 112 + 8, 4].unpack1("V")
+  end
+
+  # DLL name => the function names imported from it.
+  def imports
+    dlls = Hash.new { |imported, dll| imported[dll] = [] }
+    descriptor = offset_of(@import_table)
+
+    loop do
+      lookup, _timestamp, _forwarder, name, addresses = @image[descriptor, 20].unpack("V5")
+      break if lookup.zero? && name.zero? && addresses.zero?
+
+      # Both tables list the same imports. The lookup table is the one that
+      # keeps their names; the address table is overwritten with the resolved
+      # addresses when the image is bound, and is missing from some linkers.
+      thunk = offset_of(lookup.zero? ? addresses : lookup)
+      dll = string_at(name)
+
+      until (entry = @image[thunk, 8].unpack1("Q<")).zero?
+        # The top bit marks an import by ordinal, which carries no name. The
+        # rest is the address of a two byte hint followed by the name.
+        dlls[dll] << string_at((entry & 0x7fff_ffff) + 2) if entry[63].zero?
+        thunk += 8
+      end
+
+      descriptor += 20
+    end
+
+    dlls
+  end
+
+  private
+
+  def string_at(address)
+    @image[offset_of(address)..].unpack1("Z*")
+  end
+
+  # Addresses in the image are relative to where it would be loaded. The file
+  # lays the same bytes out differently, section by section.
+  def offset_of(address)
+    section = @sections.find { |s| (s[:address]...s[:address] + s[:size]).cover?(address) }
+    raise ArgumentError, "address 0x#{address.to_s(16)} falls in no section" unless section
+
+    address - section[:address] + section[:raw]
+  end
+end


### PR DESCRIPTION
I need to render around a million documents a month, mostly invoices. That runs today on [texd](https://github.com/digineo/texd), a LaTeX render daemon I built and still operate. It works, but an invoice takes about 3 seconds, so all of the throughput has to come from running many containers and none of it from the renderer being quick.

typst looks like a much better fit, and typst-rb is the natural way to reach it from a Rails app. When I put the gem under the load I actually have, two things got in the way, and neither was typst itself:

* A compile held Ruby's global VM lock, so a thread pool (think: Sidekiq) did nothing. Eight threads produced exactly as many documents per second as one.
* Every compile walked the system font directories from scratch, about 95 ms on a box with 2000 fonts installed. For an invoice that was 97% of the call.
  (Granted, this is on my personal machine that has [`fonts-noto-extra`](https://packages.debian.org/forky/fonts-noto-extra) installed - which alone ships 1000 font files... I suspect typical production systems will have a lot less fonts).

Both are fixed here. On the same 24-core machine, `test/invoice.typ` (the `invoice-maker` package, 20 line items, warm package cache), Ruby 4.0.6, typst 0.15.1:

|           |                      main |              this branch |
|:----------|--------------------------:|-------------------------:|
| 1 thread  | 96.69 ms/doc, 10.3 docs/s |  1.84 ms/doc, 543 docs/s |
| 8 threads | 96.34 ms/doc, 10.4 docs/s | 0.38 ms/doc, 2602 docs/s |

A month of my documents is 8 minutes of wall clock at the bottom right of that table, against 27 hours at the top left. I am not asking anyone to care about my volume in particular, but it is what turned up these two problems, and they are not specific to it: the font scan is pure fixed cost on every call, and the GVL means a Puma worker running a compile serves nobody else meanwhile.

## Full disclorure

I'm not proficient in Rust nor low-level Windows functions, and have taken the help of Claude Code to prototype the implementation and fix the issues surfaced under Windows.

## What changed

Five commits, each standing mostly on their own.

### `5dec050` ci: add pure test run

Tests were run only on Gem release. This adds a matrix of Ruby 3.0 through 4.0 across Linux, macOS and Windows that compiles and runs the suite. It comes first because the two commits after it are exactly the kind that need it.

Feel free to drop this commit from the merge, if test-on-compile is not desired or eats too much into your Github Action budget. I've noticed the Windows runner needing 5+ minutes for a workflow run, while the others stay at around 3 minutes.

### `00d4d22` feat: release the GVL while compiling

`ext/typst/src/nogvl.rs` wraps `rb_thread_call_without_gvl`, and the five entry points in `lib.rs` now run inside it. The closure never touches the Ruby API, so all conversion happens before and after; a Rust panic is caught inside the region and resumed once the GVL is back, because unwinding across Ruby's C frame is undefined.

No unblocking function is registered, so a compile still cannot be interrupted. That is not a regression: holding the GVL made it uninterruptible anyway.

`test/concurrency_test.rb` is new and covers the parts that actually break when threads share a compiler: results not mixing between documents, `sys_inputs` staying with their own compile, and warnings and errors staying with theirs.

It also covers the release itself, which nothing else in the file would notice going away - a serial compiler passes every other test in there. A Ruby thread counts in a loop while one compile runs, and an extension holding the GVL never yields to it, so the counter reads exactly zero in that case and millions in this one. No wall clock and no core count involved. Verified in both directions: with `without_gvl` short-circuited to call its closure directly, it fails at zero, five runs out of five.

### `2e1dc9c` fix: bind Sleep to the Win32 call, not to Ruby's

This is the subtle one, and it is worth reading `build.rs` and the doc comments in `nogvl.rs` before the diff.

Releasing the GVL killed the interpreter on Windows as soon as two threads compiled:

```
[BUG] win32_mutex_lock: WAIT_ABANDONED
```

The Ruby DLL exports a symbol named `Sleep`. It is `rb_w32_Sleep` from `thread_win32.c`, and its whole body is a `BLOCKING_REGION`, so it releases and reacquires the GVL. rb_sys puts libruby ahead of the system import libraries on the link line, and ld binds an undefined symbol to the first library that offers it, so `Sleep` resolved to Ruby's. `parking_lot` calls it while spinning for a contended lock, which a compile reaches through comemo's cache.

Called from a thread that has already released the GVL, that releases a mutex the thread does not own (silently, Ruby ignores what `ReleaseMutex` returns) and then takes the GVL for a thread meant to be outside it. The recursive Win32 mutex never gets its count back to zero, so it is abandoned when the thread exits and the next waiter dies.

Neither link order nor a local definition can settle it, so `build.rs` links with `--wrap=Sleep` and `--wrap=__imp_Sleep` (the dllimport spelling needs its own wrap, mingw's `_CRT_INIT` reaches it that way) and the wrapper calls `SleepEx(ms, FALSE)`, the same wait without the alertable part, which libruby does not export.

`test/windows_test.rb` asserts the invariant against the extension's import table rather than a disassembly, since the call was always indirect. It also runs a barely throttled evictor against four compiling threads in a child interpreter, because a `[BUG]` abort takes the whole process with it and no assertion inside it would ever run. The child reports each document it finishes and the parent counts them, so the timeout only has to catch a stall rather than judge how slow a shared runner is allowed to be.

This is GNU-toolchain only, which is what the published `x64-mingw-ucrt` binaries use. An MSVC build links `Sleep` the same way and would need its own answer.

### `ce6a26b` feat: discover fonts once per process

`SystemWorldBuilder::build` called `build_font_store` on every compile, which ran `fonts::system()` from scratch. Discovery now happens once, in two layers that are both needed:

* The system font locations and the parsed embedded fonts are cached. `FontStore` is not `Clone`, so a compile that brings its own font paths fills a fresh store from those lists rather than rescanning.
* One assembled `Arc<FontStore>` per combination of the two ignore flags, used when `font_paths` is empty. Sharing it keeps the fonts a document uses loaded and hashes the font book only once. That second layer is worth another 4 ms per compile on top of caching discovery alone, because refilling 2000 faces and rehashing the book is not free either.

Directories in `font_paths` stay uncached on purpose. `build_world_from_s` writes a fresh temporary directory per call, so keying a cache on them would never hit while growing without bound.

This adds a new public API, `Typst.clear_font_cache`, for a process that outlives a font installation. See the open question below.

### `dd89a07` fix: keep the font paths from_s was given

Found while testing the previous commit: `build_world_from_s` owns the main file and the root of the temporary directory it builds, and it assigned `options[:font_paths]` the same way. Font paths are not its to own:

```ruby
Typst::Pdf.from_s(body, font_paths: ["vendor/fonts"])   # silently dropped
Typst(body: body).with_font_paths(["vendor/fonts"])     # silently dropped
Typst::Pdf.from_zip("doc.zip", font_paths: [...])       # silently dropped
```

`with_font_paths` appends, so the two had disagreed since the method was introduced. The temporary fonts directory is now appended to whatever the caller passed, and only created when `fonts:` is non-empty.

That second half is not cosmetic. An empty directory on the font path takes the compile off the shared store and costs a scan, 1.45 ms per document, so `from_s` went from 95.75 ms to 0.58 ms per document.

## Behaviour changes

* Fonts installed or removed after the first compile are invisible until `Typst.clear_font_cache` is called. typst's own CLI never faces this because it rebuilds per invocation.
* `from_s`, `from_zip` and `Typst(body:)` keep the `font_paths` they are given instead of dropping them. Anyone who was relying on them being dropped would be relying on a bug, but it is a behaviour change.
* `from_s` and `from_zip` no longer create an empty `fonts` directory in their temporary directory when no `fonts:` were passed.
* Compiles now run concurrently for real, which makes the package storage problem below reachable where it was not before.

## What this does not fix

Worth knowing before merging, all of it documented in the README:

* Package storage is not safe to populate concurrently. Threads needing the same not-yet-cached package each download their own copy and untar it into the same directory, over each other; on Windows that fails outright rather than clobbering. Compile once to warm the cache before fanning out. Reading a package already on disk from many threads is safe, and that is what `test_concurrent_package_obtain` covers.
* A compile still cannot be interrupted. `Thread#kill` and `Ctrl-C` take effect   once it returns.
* `Typst.clear_cache` takes comemo's write lock, so calling it in a loop while other threads compile starves them. Measured at 400x with four compiling threads and one evicting flat out. Call it between batches, not between documents.
* Ractor and `fork` safety is neither addressed nor attempted. The font cache, the comemo cache and package storage are all process-global.
* typst parallelizes page runs, so a single-layout document stays on roughly one core no matter how many threads it gets. Everything above is throughput across documents, not speed within one.

## Open question

`Typst.clear_font_cache` is new public API and I would rather you picked its shape than inherit mine.

The alternative was to accept the staleness with no API at all, on the grounds that a server process restarts often enough and mid-process font installations are rare. I went with the explicit escape hatch because a long-lived Rails process is exactly the case that hits it, but if you would rather not grow the surface, dropping it is a small revert.

## Testing

`bundle exec rake test` is green on this machine at 43 tests, and the new CI matrix runs it on Ruby 3.0 through 4.0 across all three platforms.

New coverage:

* `test/concurrency_test.rb`, 9 tests: the GVL actually being released, results and `sys_inputs` and warnings and errors staying with their own compile, and both cache-clearing calls racing live compiles. The package test compiles once before it fans out, because a cold cache is the racy path this branch does not fix and every CI runner starts cold.
* `test/windows_test.rb`, 3 tests: the import-table invariants for the `Sleep` wrap, and a barely throttled evictor in a child interpreter, counted by the documents the child reports finishing.
* `test/typst_test.rb`: `font_paths` being rescanned every compile (the deliberate hole in the font cache), and the caller's font paths surviving `from_s`, `from_zip`, `Typst(body:)` and `with_font_paths`, in both directions.

The two tests for the caller's font paths surviving fail without `dd89a07`, which is how I convinced myself the old behaviour was a bug rather than a decision.

Two gaps I did not address:

* Panic surfacing through `without_gvl` cannot be triggered from Ruby, and a Rust-side test is awkward with a `cdylib`-only crate
type.
* Nothing covers a system font installed after the first compile becoming visible after `clear_font_cache`, because it would have to move `$HOME` and rely on the machine's fontconfig listing `~/.fonts`, which is too fragile to be worth it. The concurrent clear is covered.

## Where this suite can go flaky

Concurrency tests in a language without proper concurrency primitives are a good way to buy an intermittently red CI, so here is what I know is left in this one. None of it is currently red, neither on my machine nor on CI.

* The two cache-clearing tests assert from inside their worker threads, and test-unit's `TestResult` has no lock anywhere - `@assertion_count += 1` and the listener notification both run unguarded. Two threads failing in the same test can garble the report. Collecting values in the threads and asserting on the main one after the join is the fix; I have not done it, because it costs a rewrite of both tests to protect a case that only shows up on a run that is already failing.
* The GVL test assumes the measured compile fits inside one Ruby timeslice. It is preceded by a warm-up and a `Thread.pass` so it starts on a fresh one, but a machine slow enough to spend 100 ms on a warm 200 row table would let the ticker be scheduled on return and count after the fact. That direction fails safe: it can mask a regression, it cannot redden a good build.
* `test_warnings_stay_with_their_own_compile` matches on `unknown font family` and requires the even-numbered threads to produce no warnings at all. Both are hostage to typst's wording and to what typst decides is worth warning about in a future release.
* `test_concurrent_package_obtain` reaches the network on a machine with a cold package cache, which every CI runner is. It downloads once, serially, before it fans out, so the racy path is not exercised - but packages.typst.org being down is still a red build.
* The Windows child test is the one that gets slow rather than wrong on a two core runner, such as Github Actions. The 180 second timeout is there to turn a stall into a failure; the assertion that matters is the count of documents the child reports.
* Every test shares one process and the caches are all process-global, so a test that clears one changes the timing of the tests after it. The two clearing threads are now stopped in an `ensure`, which is what keeps a single failure from leaving an evictor running for the rest of the suite.
